### PR TITLE
chore: CICD workflow 적용

### DIFF
--- a/.github/workflow/deploy.yml
+++ b/.github/workflow/deploy.yml
@@ -1,0 +1,40 @@
+name: YOLOGA CI/CD
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+
+      - name: Execute deploy.sh
+        uses: appleboy/ssh-action@master
+        with:
+          username: ${{ secrets.GCP_ACCOUNT_GMAIL_ID }}
+          host: ${{ secrets.GCP_HOST }}
+          port: ${{ secrets.GCP_SSH_PORT }}
+          key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GCP_SSH_PRIVATE_KEY_PASSPHRASE }}
+          script: |
+            rm -rf yologa-api
+            git clone -b develop https://github.com/dobugs/yologa-api.git
+            mv ./yologa-api/scripts/deploy.sh ./deploy.sh
+            sh deploy.sh


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-40

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 추후 추가될 `develop` 브랜치에 push 또는 PR 이 완료될 경우 동작하는 workflow 입니다.
- CI 과정 및 [이전 PR](https://github.com/dobugs/yologa-api/pull/2)에서 작성한 배포 스크립트를 서버로 보내 실행하는 과정이 포함되어 있습니다.
- 외부에서 접속 가능하게 하기 위해 8080 포트를 열어두었습니다. (Google Cloud 방화벽 설정)

## 관련 Docs

- [Github Actions 를 이용한 CI/CD 적용](https://cactus-treatment-26e.notion.site/Github-Actions-CI-CD-bd1611e18e084cb2b05991fe5529169b)
  - CICD 과정을 정리한 노션 문서입니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
