### PR TITLE
feat: API 문서 자동화 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .gradle
 build/
+docs/
+src/main/resources/static/docs/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/build.gradle
+++ b/build.gradle
@@ -33,22 +33,33 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java:8.0.26'
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-}
-
 ext {
     snippetsDir = file('build/generated-snippets')
 }
 
 test {
     outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java:8.0.26'
 }
 
+/* RestDocs Start */
 ext {
     snippetsDir = file('build/generated-snippets')
 }
@@ -68,3 +69,4 @@ bootJar {
         into 'static/docs'
     }
 }
+/* RestDocs End */

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.1'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.dobugs'
@@ -10,6 +11,10 @@ sourceCompatibility = '17'
 
 repositories {
     mavenCentral()
+}
+
+configurations {
+    asciidoctorExt
 }
 
 dependencies {
@@ -21,6 +26,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java:8.0.26'
@@ -28,4 +35,25 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -1,0 +1,30 @@
+= 러닝크루 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 러닝크루 생성
+Request
+include::{snippets}/running-crew/create/http-request.adoc[]
+Response
+include::{snippets}/running-crew/create/http-response.adoc[]
+
+== 러닝크루 상세정보 조회
+Request
+include::{snippets}/running-crew/findById/http-request.adoc[]
+Response
+include::{snippets}/running-crew/findById/http-response.adoc[]
+
+== 러닝크루 수정
+Request
+include::{snippets}/running-crew/update/http-request.adoc[]
+Response
+include::{snippets}/running-crew/update/http-response.adoc[]
+
+== 러닝크루 삭제
+Request
+include::{snippets}/running-crew/delete/http-request.adoc[]
+Response
+include::{snippets}/running-crew/delete/http-response.adoc[]

--- a/src/docs/asciidoc/yologa.adoc
+++ b/src/docs/asciidoc/yologa.adoc
@@ -1,0 +1,11 @@
+= YOLOGA API 명세
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+
+== API
+=== RunningCrew API
+* link:running-crew.html[러닝크루 API, window=_blank]

--- a/src/main/java/com/dobugs/yologaapi/YologaApiApplication.java
+++ b/src/main/java/com/dobugs/yologaapi/YologaApiApplication.java
@@ -2,9 +2,7 @@ package com.dobugs.yologaapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class YologaApiApplication {
 

--- a/src/main/java/com/dobugs/yologaapi/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/dobugs/yologaapi/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.dobugs.yologaapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
@@ -6,11 +6,10 @@ import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.service.dto.common.DatesDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 @Getter
 public class RunningCrewResponse {
 

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -1,0 +1,132 @@
+package com.dobugs.yologaapi.controller;
+
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewCreateRequest;
+import static org.hamcrest.Matchers.is;
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewResponse;
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewUpdateRequest;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaapi.service.RunningCrewService;
+import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
+import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
+import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WebMvcTest(RunningCrewController.class)
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+@DisplayName("RunningCrew 컨트롤러 테스트")
+class RunningCrewControllerTest {
+
+    private static final String BASIC_URL = "/api/v1/running-crews";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private RunningCrewService runningCrewService;
+
+    @DisplayName("러닝크루를 생성한다")
+    @Test
+    void create() throws Exception {
+        final RunningCrewCreateRequest request = createRunningCrewCreateRequest();
+        final String body = objectMapper.writeValueAsString(request);
+
+        final long runningCrewId = 1L;
+        given(runningCrewService.create(any())).willReturn(runningCrewId);
+
+        mockMvc.perform(post(BASIC_URL)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("location", BASIC_URL + "/" + runningCrewId))
+            .andDo(document(
+                "running-crew/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("러닝크루의 상세정보를 조회한다")
+    @Test
+    void findById() throws Exception {
+        final long runningCrewId = 1L;
+
+        final RunningCrewResponse response = createRunningCrewResponse(runningCrewId);
+        given(runningCrewService.findById(runningCrewId)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/" + runningCrewId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("id", is(Integer.parseInt(String.valueOf(runningCrewId)))))
+            .andDo(document(
+                "running-crew/findById",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("러닝크루를 수정한다")
+    @Test
+    void update() throws Exception {
+        final long runningCrewId = 1L;
+        final RunningCrewUpdateRequest request = createRunningCrewUpdateRequest();
+        final String body = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(put(BASIC_URL + "/" + runningCrewId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "running-crew/update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("러닝크루를 삭제한다")
+    @Test
+    void deleteTest() throws Exception {
+        final long runningCrewId = 1L;
+
+        mockMvc.perform(delete(BASIC_URL + "/" + runningCrewId))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "running-crew/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
@@ -14,9 +14,11 @@ import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrewProgression;
 import com.dobugs.yologaapi.service.dto.common.CoordinatesDto;
 import com.dobugs.yologaapi.service.dto.common.DateDto;
+import com.dobugs.yologaapi.service.dto.common.DatesDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
+import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -35,6 +37,8 @@ public class RunningCrewFixture {
     public static final LocalDateTime NOW = LocalDateTime.now();
     public static final LocalDateTime AFTER_ONE_HOUR = LocalDateTime.now().plusHours(1);
     public static final DateDto DATE_DTO = new DateDto(NOW, AFTER_ONE_HOUR);
+    public static final DateDto NOT_IMPLEMENTED_DATE_DTO = new DateDto(null, null);
+    public static final DatesDto DATES_DTO = new DatesDto(DATE_DTO, NOT_IMPLEMENTED_DATE_DTO);
 
     public static final CoordinatesDto COORDINATES_DTO = new CoordinatesDto(LATITUDE, LONGITUDE);
     public static final LocationsDto LOCATIONS_DTO = new LocationsDto(COORDINATES_DTO, COORDINATES_DTO);
@@ -82,6 +86,13 @@ public class RunningCrewFixture {
     public static RunningCrewUpdateRequest createRunningCrewUpdateRequest() {
         return new RunningCrewUpdateRequest(
             RUNNING_CREW_TITLE, LOCATIONS_DTO, RUNNING_CREW_CAPACITY, DATE_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
+        );
+    }
+
+    public static RunningCrewResponse createRunningCrewResponse(final Long runningCrewId) {
+        return new RunningCrewResponse(
+            runningCrewId, RUNNING_CREW_TITLE, 1L, LOCATIONS_DTO, RunningCrewProgression.CREATED.name(),
+            RUNNING_CREW_CAPACITY, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
         );
     }
 


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-24

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- API 문서 최신화 및 접근성을 위해 `RestDocs` 을 도입하였습니다.

## 관련 Docs

- [RestDocs 이용하여 API 문서 자동화](https://cactus-treatment-26e.notion.site/RestDocs-API-901d333ddb72498a911e48fe2fba3be2)
  - 도입 과정을 정리한 노션 문서입니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
