### PR TITLE
chore: 코드 커버리지 툴 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,11 @@ jacocoTestReport {
 
 jacocoTestCoverageVerification {
 
+    def exceptions = [
+            "*.exception.*",
+            "*.*Application"
+    ]
+
     violationRules {
         rule {
             enabled = true
@@ -104,8 +109,10 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.50
+                minimum = 0.90
             }
+
+            excludes = [] + exceptions
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.0.1'
     id 'io.spring.dependency-management' version '1.1.0'
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id "jacoco"
 }
 
 group = 'com.dobugs'
@@ -70,3 +71,42 @@ bootJar {
     }
 }
 /* RestDocs End */
+
+/* JaCoCo Start */
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+test {
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        csv.enabled true
+        xml.enabled false
+
+        html.destination file("$buildDir/reports/jacoco/html")
+        csv.destination file("$buildDir/reports/jacoco/jacoco.csv")
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+        }
+    }
+}
+/* JaCoCo End */

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -2,11 +2,13 @@ package com.dobugs.yologaapi.domain.runningcrew;
 
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.AFTER_ONE_HOUR;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.COORDINATES;
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.NOW;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.RUNNING_CREW_CAPACITY;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.RUNNING_CREW_DESCRIPTION;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.RUNNING_CREW_TITLE;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrew;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewWith;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
@@ -21,6 +23,16 @@ class RunningCrewTest {
     @DisplayName("러닝크루 객체 생성 테스트")
     @Nested
     public class createTest {
+
+        @DisplayName("러닝크루를 생성한다")
+        @Test
+        void create() {
+            assertThatCode(() -> new RunningCrew(
+                    1L, COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
+                    NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
+                    RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+            )).doesNotThrowAnyException();
+        }
 
         @DisplayName("시작 시간은 종료 시간보다 앞서있어야 한다")
         @Test
@@ -39,6 +51,22 @@ class RunningCrewTest {
     @DisplayName("러닝크루 수정 테스트")
     @Nested
     public class updateTest {
+
+        @DisplayName("러닝크루를 수정한다")
+        @Test
+        void update() {
+            final RunningCrew runningCrew = new RunningCrew(
+                1L, COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
+                NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
+                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+            );
+
+            assertThatCode(() -> runningCrew.update(
+                COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
+                NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
+                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+            )).doesNotThrowAnyException();
+        }
 
         @DisplayName("시작 시간은 종료 시간보다 앞서있어야 한다")
         @Test


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-26

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 코드 커버리지를 측정하기 위해 `jacoco` 를 적용하였습니다.
- `LINE` 이 90% 이상 실행되어야 통과됩니다.
- `exception` 이나 `YologaApiApplication` 처럼 측정이 의미가 없는 클래스들은 제외하였습니다.

## 관련 Docs

- [코드 커버리지 측정을 위한 JaCoCo 적용](https://cactus-treatment-26e.notion.site/JaCoCo-01b41200fee04008828dcf1eb81d51dd)
  - 자코코 적용 과정을 정리한 노션 문서입니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
