### PR TITLE
chore: jacoco 평가 기준에 dto 패키지 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,8 @@ jacocoTestCoverageVerification {
 
     def exceptions = [
             "*.exception.*",
-            "*.*Application"
+            "*.*Application",
+            "*.dto.*"
     ]
 
     violationRules {


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-78

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 이전 PR 에서 추가된 DTO(RunningCrewResponse, LocationDto) 로 인해 jacoco 가 실패하여 빌드가 실패하였습니다.
- 따라서 DTO 자체를 평가 기준에서 제외하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
