### PR TITLE
chore: MySQL 8.0.28 로 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'mysql:mysql-connector-java:8.0.26'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.28'
 }
 
 /* RestDocs Start */


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-96

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

![image](https://user-images.githubusercontent.com/92148749/213917806-c608b901-728d-446e-9c3b-6cb6d106da35.png)

- 취약 버전인 `MySQL 8.0.26` 에서 권장하는 `MySQL 8.0.28` 으로 업그레이드하였다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
