### PR TITLE
chore: Build 시 Repository 테스트 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ ext {
 }
 
 test {
+    exclude 'com/dobugs/yologaapi/repository/*'
+
     outputs.dir snippetsDir
     useJUnitPlatform()
 }
@@ -99,7 +101,8 @@ jacocoTestCoverageVerification {
     def exceptions = [
             "*.exception.*",
             "*.*Application",
-            "*.dto.*"
+            "*.dto.*",
+            "*.BaseEntity"
     ]
 
     violationRules {


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-104

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 테스트 시 로컬 DB 를 사용하도록 설정되어 있었기 때문에 계속해서 Github Actions 가 실패하였다.
- 추후에 Jenkins 도입을 위해서는 빌드 -> jar 파일 실행의 과정을 유지해야 했는데, 빌드 시에는 원하는 profile 을 설정할 수 없다.
- 테스트에서 별도의 profile 을 지정하기 위해서는 테스트 코드(ex. @Profile, @ActiveProfiles) 에 매번 작성해야 하는데 이는 유지보수성이 떨어진다고 판단하였다.
- H2 데이터베이스도 고려하였으나 MySQL 에서 제공하는 함수를 사용할 수 없다는 단점이 있어서 제외하였다.
- 따라서 **테스트는 개발 시에 진행하고, 빌드 시에는 DB 관련 테스트를 제외하였다.**
  - 모든 테스트를 제외해도 되지만 RestDocs API 문서를 만들기 위해서는 Controller 테스트가 필요하여 최소한으로만 제외하였다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
