### PR TITLE
chore: Github Actions CI 에서 push 작업 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: YOLOGA CI
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-115

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- PR 머지 후 동일한 Actions 작업이 한 번 더 발생하여 push 의 설정을 제거하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
