### PR TITLE
feat: 러닝크루 참여 기능 구현

### DIFF
--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -52,3 +52,9 @@ Request
 include::{snippets}/participation/participate/http-request.adoc[]
 Response
 include::{snippets}/participation/participate/http-response.adoc[]
+
+== 러닝크루 참여 요청 취소
+Request
+include::{snippets}/participation/cancel/http-request.adoc[]
+Response
+include::{snippets}/participation/cancel/http-response.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -70,3 +70,9 @@ Request
 include::{snippets}/participation/accept/http-request.adoc[]
 Response
 include::{snippets}/participation/accept/http-response.adoc[]
+
+== 러닝크루 참여 요청 거절
+Request
+include::{snippets}/participation/reject/http-request.adoc[]
+Response
+include::{snippets}/participation/reject/http-response.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -58,3 +58,9 @@ Request
 include::{snippets}/participation/cancel/http-request.adoc[]
 Response
 include::{snippets}/participation/cancel/http-response.adoc[]
+
+== 러닝크루 탈퇴
+Request
+include::{snippets}/participation/withdraw/http-request.adoc[]
+Response
+include::{snippets}/participation/withdraw/http-response.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -64,3 +64,9 @@ Request
 include::{snippets}/participation/withdraw/http-request.adoc[]
 Response
 include::{snippets}/participation/withdraw/http-response.adoc[]
+
+== 러닝크루 참여 요청 승인
+Request
+include::{snippets}/participation/accept/http-request.adoc[]
+Response
+include::{snippets}/participation/accept/http-response.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -23,6 +23,12 @@ include::{snippets}/running-crew/findById/http-request.adoc[]
 Response
 include::{snippets}/running-crew/findById/http-response.adoc[]
 
+== 러닝크루 참여자 목록 조회
+Request
+include::{snippets}/participation/findParticipants/http-request.adoc[]
+Response
+include::{snippets}/participation/findParticipants/http-response.adoc[]
+
 == 러닝크루 수정
 Request
 include::{snippets}/running-crew/update/http-request.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -46,3 +46,9 @@ Request
 include::{snippets}/running-crew/end/http-request.adoc[]
 Response
 include::{snippets}/running-crew/end/http-response.adoc[]
+
+== 러닝크루 참여 요청
+Request
+include::{snippets}/participation/participate/http-request.adoc[]
+Response
+include::{snippets}/participation/participate/http-response.adoc[]

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -1,0 +1,29 @@
+package com.dobugs.yologaapi.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dobugs.yologaapi.service.ParticipationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/running-crews/{runningCrewId}")
+@RestController
+public class ParticipationController {
+
+    private final ParticipationService participationService;
+
+    @PostMapping("/participate")
+    public ResponseEntity<Void> participate(
+        @RequestHeader("Authorization") final String accessToken,
+        @PathVariable final Long runningCrewId
+    ) {
+        participationService.participate(accessToken, runningCrewId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -44,4 +44,14 @@ public class ParticipationController {
         participationService.withdraw(accessToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/accept/{memberId}")
+    public ResponseEntity<Void> accept(
+        @RequestHeader("Authorization") final String accessToken,
+        @PathVariable final Long runningCrewId,
+        @PathVariable final Long memberId
+    ) {
+        participationService.accept(accessToken, runningCrewId, memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -35,4 +35,13 @@ public class ParticipationController {
         participationService.cancel(accessToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(
+        @RequestHeader("Authorization") final String accessToken,
+        @PathVariable final Long runningCrewId
+    ) {
+        participationService.withdraw(accessToken, runningCrewId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -1,6 +1,7 @@
 package com.dobugs.yologaapi.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaapi.service.ParticipationService;
+import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +19,12 @@ import lombok.RequiredArgsConstructor;
 public class ParticipationController {
 
     private final ParticipationService participationService;
+
+    @GetMapping("/participants")
+    public ResponseEntity<ParticipantsResponse> findParticipants(@PathVariable final Long runningCrewId) {
+        final ParticipantsResponse response = participationService.findParticipants(runningCrewId);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/participate")
     public ResponseEntity<Void> participate(

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -26,4 +26,13 @@ public class ParticipationController {
         participationService.participate(accessToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancel(
+        @RequestHeader("Authorization") final String accessToken,
+        @PathVariable final Long runningCrewId
+    ) {
+        participationService.cancel(accessToken, runningCrewId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -54,4 +54,14 @@ public class ParticipationController {
         participationService.accept(accessToken, runningCrewId, memberId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/reject/{memberId}")
+    public ResponseEntity<Void> reject(
+        @RequestHeader("Authorization") final String accessToken,
+        @PathVariable final Long runningCrewId,
+        @PathVariable final Long memberId
+    ) {
+        participationService.reject(accessToken, runningCrewId, memberId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Capacity.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Capacity.java
@@ -21,6 +21,10 @@ public class Capacity {
         this.value = value;
     }
 
+    public boolean isLeft(final int number) {
+        return number < value;
+    }
+
     private void validateCapacityIsOverStandard(final int value) {
         if (value < MINIMUM) {
             throw new IllegalArgumentException(String.format("인원은 %d 명이어야 합니다. [%d]", MINIMUM, value));

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Deadline.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Deadline.java
@@ -21,6 +21,13 @@ public class Deadline {
         this.value = value;
     }
 
+    public void validateDeadlineIsNotOver() {
+        final LocalDateTime now = LocalDateTime.now();
+        if (value.isBefore(now)) {
+            throw new IllegalArgumentException("마감기한이 지났습니다.");
+        }
+    }
+
     private void validateDeadlineIsAfterThanNow(final LocalDateTime value) {
         if (value.isBefore(LocalDateTime.now())) {
             throw new IllegalArgumentException(String.format("마감 기한이 현재 시간보다 이전입니다. [%s]", value));

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -72,13 +72,13 @@ public class Participant extends BaseEntity {
 
     private void validateMemberIsRequested(final Long memberId) {
         if (!status.isRequested()) {
-            throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, status.getName()));
+            throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, status.getDescription()));
         }
     }
 
     private void validateMemberIsParticipating(final Long memberId) {
         if (!status.isParticipating()) {
-            throw new IllegalArgumentException(String.format("참여중인 상태가 아닙니다. [%s, %s]", memberId, status.getName()));
+            throw new IllegalArgumentException(String.format("참여중인 상태가 아닙니다. [%s, %s]", memberId, status.getDescription()));
         }
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -6,9 +6,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,8 +31,13 @@ public class Participant extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private ParticipantType status;
 
-    public Participant(final Long memberId) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "running_crew_id")
+    private RunningCrew runningCrew;
+
+    public Participant(final Long memberId, final RunningCrew runningCrew) {
         this.memberId = memberId;
         this.status = ParticipantType.PARTICIPATING;
+        this.runningCrew = runningCrew;
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -35,16 +35,18 @@ public class Participant extends BaseEntity {
     @JoinColumn(name = "running_crew_id")
     private RunningCrew runningCrew;
 
-    public Participant(final RunningCrew runningCrew) {
-        this.memberId = runningCrew.getMemberId();
-        this.status = ParticipantType.PARTICIPATING;
+    public Participant(final Long memberId, final ParticipantType status, final RunningCrew runningCrew) {
+        this.memberId = memberId;
+        this.status = status;
         this.runningCrew = runningCrew;
     }
 
-    public Participant(final Long memberId, final RunningCrew runningCrew) {
-        this.memberId = memberId;
-        this.status = ParticipantType.REQUESTED;
-        this.runningCrew = runningCrew;
+    public static Participant host(final RunningCrew runningCrew) {
+        return new Participant(runningCrew.getMemberId(), ParticipantType.PARTICIPATING, runningCrew);
+    }
+
+    public static Participant member(final RunningCrew runningCrew, final Long memberId) {
+        return new Participant(memberId, ParticipantType.REQUESTED, runningCrew);
     }
 
     public void withdraw() {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -41,12 +41,13 @@ public class Participant extends BaseEntity {
         this.runningCrew = runningCrew;
     }
 
-    public static Participant host(final RunningCrew runningCrew) {
-        return new Participant(runningCrew.getMemberId(), ParticipantType.PARTICIPATING, runningCrew);
+    public static Participant requested(final RunningCrew runningCrew, final Long memberId) {
+        return new Participant(memberId, ParticipantType.REQUESTED, runningCrew);
     }
 
-    public static Participant member(final RunningCrew runningCrew, final Long memberId) {
-        return new Participant(memberId, ParticipantType.REQUESTED, runningCrew);
+    public void participate() {
+        validateMemberIsRequested(memberId);
+        this.status = ParticipantType.PARTICIPATING;
     }
 
     public void cancel() {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -1,0 +1,35 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import com.dobugs.yologaapi.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Participant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long memberId;
+
+    @Enumerated(value = EnumType.STRING)
+    private ParticipantType status;
+
+    public Participant(final Long memberId) {
+        this.memberId = memberId;
+        this.status = ParticipantType.PARTICIPATING;
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -46,4 +46,8 @@ public class Participant extends BaseEntity {
         this.status = ParticipantType.REQUESTED;
         this.runningCrew = runningCrew;
     }
+
+    public boolean isRequested() {
+        return status.isRequested();
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -49,6 +49,11 @@ public class Participant extends BaseEntity {
         return new Participant(memberId, ParticipantType.REQUESTED, runningCrew);
     }
 
+    public void cancel() {
+        validateMemberIsRequested(memberId);
+        this.status = ParticipantType.CANCELLED;
+    }
+
     public void withdraw() {
         validateMemberIsParticipating(memberId);
         this.status = ParticipantType.WITHDRAWN;
@@ -56,6 +61,12 @@ public class Participant extends BaseEntity {
 
     public boolean isRequested() {
         return status.isRequested();
+    }
+
+    private void validateMemberIsRequested(final Long memberId) {
+        if (!status.isRequested()) {
+            throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, status.getName()));
+        }
     }
 
     private void validateMemberIsParticipating(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -35,9 +35,15 @@ public class Participant extends BaseEntity {
     @JoinColumn(name = "running_crew_id")
     private RunningCrew runningCrew;
 
+    public Participant(final RunningCrew runningCrew) {
+        this.memberId = runningCrew.getMemberId();
+        this.status = ParticipantType.PARTICIPATING;
+        this.runningCrew = runningCrew;
+    }
+
     public Participant(final Long memberId, final RunningCrew runningCrew) {
         this.memberId = memberId;
-        this.status = ParticipantType.PARTICIPATING;
+        this.status = ParticipantType.REQUESTED;
         this.runningCrew = runningCrew;
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -59,8 +59,9 @@ public class Participant extends BaseEntity {
         this.status = ParticipantType.WITHDRAWN;
     }
 
-    public boolean isRequested() {
-        return status.isRequested();
+    public void accept() {
+        validateMemberIsRequested(memberId);
+        this.status = ParticipantType.PARTICIPATING;
     }
 
     private void validateMemberIsRequested(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -47,7 +47,18 @@ public class Participant extends BaseEntity {
         this.runningCrew = runningCrew;
     }
 
+    public void withdraw() {
+        validateMemberIsParticipating(memberId);
+        this.status = ParticipantType.WITHDRAWN;
+    }
+
     public boolean isRequested() {
         return status.isRequested();
+    }
+
+    private void validateMemberIsParticipating(final Long memberId) {
+        if (!status.isParticipating()) {
+            throw new IllegalArgumentException(String.format("참여중인 상태가 아닙니다. [%s, %s]", memberId, status.getName()));
+        }
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participant.java
@@ -64,6 +64,11 @@ public class Participant extends BaseEntity {
         this.status = ParticipantType.PARTICIPATING;
     }
 
+    public void reject() {
+        validateMemberIsRequested(memberId);
+        this.status = ParticipantType.REJECTED;
+    }
+
     private void validateMemberIsRequested(final Long memberId) {
         if (!status.isRequested()) {
             throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, status.getName()));

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -20,4 +20,8 @@ public enum ParticipantType {
     public boolean isRequested() {
         return this == REQUESTED;
     }
+
+    public boolean isParticipating() {
+        return this == PARTICIPATING;
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -1,10 +1,19 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
+import lombok.Getter;
+
+@Getter
 public enum ParticipantType {
 
-    REQUESTED,
-    PARTICIPATING,
-    REJECTED,
-    WITHDRAWN,
+    REQUESTED("참여 요청"),
+    PARTICIPATING("참여중"),
+    REJECTED("참여 거절"),
+    WITHDRAWN("탈퇴"),
     ;
+
+    private final String name;
+
+    ParticipantType(final String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum ParticipantType {
 
     REQUESTED("참여 요청"),
+    CANCELLED("참여 요청 취소"),
     PARTICIPATING("참여중"),
     REJECTED("참여 거절"),
     WITHDRAWN("탈퇴"),

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -1,0 +1,10 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+public enum ParticipantType {
+
+    REQUESTED,
+    PARTICIPATING,
+    REJECTED,
+    WITHDRAWN,
+    ;
+}

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -16,4 +16,8 @@ public enum ParticipantType {
     ParticipantType(final String name) {
         this.name = name;
     }
+
+    public boolean isRequested() {
+        return this == REQUESTED;
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantType.java
@@ -5,17 +5,19 @@ import lombok.Getter;
 @Getter
 public enum ParticipantType {
 
-    REQUESTED("참여 요청"),
-    CANCELLED("참여 요청 취소"),
-    PARTICIPATING("참여중"),
-    REJECTED("참여 거절"),
-    WITHDRAWN("탈퇴"),
+    REQUESTED("참여 요청", "REQUESTED"),
+    CANCELLED("참여 요청 취소", "CANCELLED"),
+    PARTICIPATING("참여중", "PARTICIPATING"),
+    REJECTED("참여 거절", "REJECTED"),
+    WITHDRAWN("탈퇴", "WITHDRAWN"),
     ;
 
-    private final String name;
+    private final String description;
+    private final String savedName;
 
-    ParticipantType(final String name) {
-        this.name = name;
+    ParticipantType(final String description, final String savedName) {
+        this.description = description;
+        this.savedName = savedName;
     }
 
     public boolean isRequested() {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -19,7 +19,7 @@ public class Participants {
     private List<Participant> value = new ArrayList<>();
 
     public Participants(final RunningCrew runningCrew) {
-        value.add(new Participant(runningCrew.getMemberId(), runningCrew));
+        value.add(new Participant(runningCrew));
     }
 
     public void add(final RunningCrew runningCrew, final Long memberId) {
@@ -34,6 +34,14 @@ public class Participants {
         final int numberOfParticipants = value.size();
         if (!capacity.isLeft(numberOfParticipants)) {
             throw new IllegalArgumentException("참여자 수용인원이 다 찼습니다.");
+        }
+    }
+
+    public void validateMemberIsNotParticipant(final Long memberId) {
+        for (final Participant participant : value) {
+            if (participant.getMemberId().equals(memberId)) {
+                throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getName()));
+            }
         }
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -32,6 +32,11 @@ public class Participants {
         value.remove(participant);
     }
 
+    public void withdraw(final Long memberId) {
+        final Participant participant = findParticipant(memberId);
+        participant.withdraw();
+    }
+
     public void validateCapacityIsOver(final Capacity capacity) {
         final int numberOfParticipants = value.size();
         if (!capacity.isLeft(numberOfParticipants)) {
@@ -52,6 +57,13 @@ public class Participants {
         if (!participant.isRequested()) {
             throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, participant.getStatus().getName()));
         }
+    }
+
+    public int getNumberOrParticipants() {
+        final List<Participant> participants = value.stream()
+            .filter(value -> value.getStatus().isParticipating())
+            .toList();
+        return participants.size();
     }
 
     private Participant findParticipant(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -59,7 +59,7 @@ public class Participants {
     private void validateMemberIsNotParticipant(final Long memberId) {
         for (final Participant participant : value) {
             if (participant.getMemberId().equals(memberId)) {
-                throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getName()));
+                throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getDescription()));
             }
         }
     }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -19,12 +19,14 @@ public class Participants {
     private List<Participant> value = new ArrayList<>();
 
     public Participants(final RunningCrew runningCrew) {
-        value.add(Participant.host(runningCrew));
+        final Participant participant = Participant.requested(runningCrew, runningCrew.getMemberId());
+        participant.participate();
+        value.add(participant);
     }
 
     public void temporaryJoin(final RunningCrew runningCrew, final Long memberId) {
         validateMemberIsNotParticipant(memberId);
-        value.add(Participant.member(runningCrew, memberId));
+        value.add(Participant.requested(runningCrew, memberId));
     }
 
     public void cancel(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -29,8 +29,7 @@ public class Participants {
 
     public void cancel(final Long memberId) {
         final Participant participant = findParticipant(memberId);
-        validateMemberIsRequested(participant);
-        value.remove(participant);
+        participant.cancel();
     }
 
     public void withdraw(final Long memberId) {
@@ -50,14 +49,6 @@ public class Participants {
             if (participant.getMemberId().equals(memberId)) {
                 throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getName()));
             }
-        }
-    }
-
-    private void validateMemberIsRequested(final Participant participant) {
-        if (!participant.isRequested()) {
-            throw new IllegalArgumentException(String.format(
-                "참여 요청인 상태가 아닙니다. [%s, %s]", participant.getMemberId(), participant.getStatus().getName()
-            ));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -37,6 +37,11 @@ public class Participants {
         participant.withdraw();
     }
 
+    public void accept(final Long memberId) {
+        final Participant participant = findParticipant(memberId);
+        participant.accept();
+    }
+
     public void validateCapacityIsOver(final Capacity capacity) {
         final int numberOfParticipants = value.size();
         if (!capacity.isLeft(numberOfParticipants)) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -22,13 +22,14 @@ public class Participants {
         value.add(Participant.host(runningCrew));
     }
 
-    public void add(final RunningCrew runningCrew, final Long memberId) {
+    public void temporaryJoin(final RunningCrew runningCrew, final Long memberId) {
         validateMemberIsNotParticipant(memberId);
         value.add(Participant.member(runningCrew, memberId));
     }
 
-    public void delete(final Long memberId) {
+    public void cancel(final Long memberId) {
         final Participant participant = findParticipant(memberId);
+        validateMemberIsRequested(participant);
         value.remove(participant);
     }
 
@@ -44,7 +45,7 @@ public class Participants {
         }
     }
 
-    public void validateMemberIsNotParticipant(final Long memberId) {
+    private void validateMemberIsNotParticipant(final Long memberId) {
         for (final Participant participant : value) {
             if (participant.getMemberId().equals(memberId)) {
                 throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getName()));
@@ -52,10 +53,11 @@ public class Participants {
         }
     }
 
-    public void validateMemberIsRequested(final Long memberId) {
-        final Participant participant = findParticipant(memberId);
+    private void validateMemberIsRequested(final Participant participant) {
         if (!participant.isRequested()) {
-            throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, participant.getStatus().getName()));
+            throw new IllegalArgumentException(String.format(
+                "참여 요청인 상태가 아닙니다. [%s, %s]", participant.getMemberId(), participant.getStatus().getName()
+            ));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -42,6 +42,11 @@ public class Participants {
         participant.accept();
     }
 
+    public void reject(final Long memberId) {
+        final Participant participant = findParticipant(memberId);
+        participant.reject();
+    }
+
     public void validateCapacityIsOver(final Capacity capacity) {
         final int numberOfParticipants = value.size();
         if (!capacity.isLeft(numberOfParticipants)) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -1,0 +1,34 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+
+public class Participants {
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "running_crew_id")
+    private List<Participant> value = new ArrayList<>();
+
+    public Participants(final Long memberId) {
+        value.add(new Participant(memberId));
+    }
+
+    public void add(final Long memberId) {
+        final List<Long> participants = value.stream().map(Participant::getMemberId).toList();
+        if (participants.contains(memberId)) {
+            throw new IllegalArgumentException("이미 참여된 사용자입니다.");
+        }
+        value.add(new Participant(memberId));
+    }
+
+    public void validateCapacityIsOver(final Capacity capacity) {
+        final int numberOfParticipants = value.size();
+        if (!capacity.isLeft(numberOfParticipants)) {
+            throw new IllegalArgumentException("참여자 수용인원이 다 찼습니다.");
+        }
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -23,11 +23,13 @@ public class Participants {
     }
 
     public void add(final RunningCrew runningCrew, final Long memberId) {
-        final List<Long> participants = value.stream().map(Participant::getMemberId).toList();
-        if (participants.contains(memberId)) {
-            throw new IllegalArgumentException("이미 참여된 사용자입니다.");
-        }
+        validateMemberIsNotParticipant(memberId);
         value.add(new Participant(memberId, runningCrew));
+    }
+
+    public void delete(final Long memberId) {
+        final Participant participant = findParticipant(memberId);
+        value.remove(participant);
     }
 
     public void validateCapacityIsOver(final Capacity capacity) {
@@ -43,5 +45,19 @@ public class Participants {
                 throw new IllegalArgumentException(String.format("이미 참여중입니다. [%s, %s]", memberId, participant.getStatus().getName()));
             }
         }
+    }
+
+    public void validateMemberIsRequested(final Long memberId) {
+        final Participant participant = findParticipant(memberId);
+        if (!participant.isRequested()) {
+            throw new IllegalArgumentException(String.format("참여 요청인 상태가 아닙니다. [%s, %s]", memberId, participant.getStatus().getName()));
+        }
+    }
+
+    private Participant findParticipant(final Long memberId) {
+        return value.stream()
+            .filter(value -> value.getMemberId().equals(memberId))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(String.format("참여자가 아닙니다. [%s]", memberId)));
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -19,12 +19,12 @@ public class Participants {
     private List<Participant> value = new ArrayList<>();
 
     public Participants(final RunningCrew runningCrew) {
-        value.add(new Participant(runningCrew));
+        value.add(Participant.host(runningCrew));
     }
 
     public void add(final RunningCrew runningCrew, final Long memberId) {
         validateMemberIsNotParticipant(memberId);
-        value.add(new Participant(memberId, runningCrew));
+        value.add(Participant.member(runningCrew, memberId));
     }
 
     public void delete(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -4,25 +4,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
 public class Participants {
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "running_crew_id")
+    @OneToMany(mappedBy = "runningCrew", cascade = CascadeType.ALL)
     private List<Participant> value = new ArrayList<>();
 
-    public Participants(final Long memberId) {
-        value.add(new Participant(memberId));
+    public Participants(final RunningCrew runningCrew) {
+        value.add(new Participant(runningCrew.getMemberId(), runningCrew));
     }
 
-    public void add(final Long memberId) {
+    public void add(final RunningCrew runningCrew, final Long memberId) {
         final List<Long> participants = value.stream().map(Participant::getMemberId).toList();
         if (participants.contains(memberId)) {
             throw new IllegalArgumentException("이미 참여된 사용자입니다.");
         }
-        value.add(new Participant(memberId));
+        value.add(new Participant(memberId, runningCrew));
     }
 
     public void validateCapacityIsOver(final Capacity capacity) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -1,12 +1,28 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
 public enum ProgressionType {
 
-    CREATED,
-    READY,
-    IN_PROGRESS,
-    COMPLETED,
-    CANCELLED,
-    EXPIRED,
+    CREATED("생성"),
+    READY("준비"),
+    IN_PROGRESS("진행중"),
+    COMPLETED("완료"),
+    CANCELLED("취소"),
+    EXPIRED("만료"),
     ;
+
+    private final String name;
+
+    ProgressionType(final String name) {
+        this.name = name;
+    }
+
+    public boolean isReady() {
+        final List<ProgressionType> readied = List.of(CREATED, READY);
+        return readied.contains(this);
+    }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -21,7 +21,7 @@ public enum ProgressionType {
         this.name = name;
     }
 
-    public boolean isReady() {
+    public boolean isCreatedOrReady() {
         final List<ProgressionType> readied = List.of(CREATED, READY);
         return readied.contains(this);
     }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -1,6 +1,6 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
-public enum RunningCrewProgression {
+public enum ProgressionType {
 
     CREATED,
     READY,

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -22,7 +22,10 @@ public enum ProgressionType {
     }
 
     public boolean isCreatedOrReady() {
-        final List<ProgressionType> readied = List.of(CREATED, READY);
-        return readied.contains(this);
+        return List.of(CREATED, READY).contains(this);
+    }
+
+    public boolean isCreatedOrReadyOrInProgress() {
+        return List.of(CREATED, READY, IN_PROGRESS).contains(this);
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -128,17 +128,15 @@ public class RunningCrew extends BaseEntity {
 
     public void participate(final Long memberId) {
         validateMemberIsNotHost(memberId);
-        participants.validateMemberIsNotParticipant(memberId);
         participants.validateCapacityIsOver(capacity);
         deadline.validateDeadlineIsNotOver();
         validateRunningCrewStatusIsCreatedOrReady();
-        participants.add(this, memberId);
+        participants.temporaryJoin(this, memberId);
     }
 
     public void cancel(final Long memberId) {
         validateMemberIsNotHost(memberId);
-        participants.validateMemberIsRequested(memberId);
-        participants.delete(memberId);
+        participants.cancel(memberId);
     }
 
     public void withdraw(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -135,6 +135,12 @@ public class RunningCrew extends BaseEntity {
         participants.add(this, memberId);
     }
 
+    public void cancel(final Long memberId) {
+        validateMemberIsNotHost(memberId);
+        participants.validateMemberIsRequested(memberId);
+        participants.delete(memberId);
+    }
+
     private void validateMemberIsHost(final Long memberId) {
         if (!this.memberId.equals(memberId)) {
             throw new IllegalArgumentException(String.format("호스트가 아닙니다. [%s]", memberId));

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -1,6 +1,8 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
@@ -8,6 +10,7 @@ import org.locationtech.jts.io.WKTReader;
 
 import com.dobugs.yologaapi.domain.BaseEntity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -16,6 +19,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +45,10 @@ public class RunningCrew extends BaseEntity {
 
     @Enumerated(value = EnumType.STRING)
     private RunningCrewProgression status;
+
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "running_crew_id")
+    private List<Participant> participant = new ArrayList<>();
 
     @Embedded
     private Capacity capacity;
@@ -74,6 +83,7 @@ public class RunningCrew extends BaseEntity {
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
         this.status = RunningCrewProgression.CREATED;
+        this.participant.add(new Participant(memberId));
         this.capacity = capacity;
         this.scheduledStartDate = scheduledStartDate;
         this.scheduledEndDate = scheduledEndDate;

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -44,7 +44,7 @@ public class RunningCrew extends BaseEntity {
     private Point arrival;
 
     @Enumerated(value = EnumType.STRING)
-    private RunningCrewProgression status;
+    private ProgressionType status;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "running_crew_id")
@@ -82,7 +82,7 @@ public class RunningCrew extends BaseEntity {
         this.memberId = memberId;
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
-        this.status = RunningCrewProgression.CREATED;
+        this.status = ProgressionType.CREATED;
         this.participant.add(new Participant(memberId));
         this.capacity = capacity;
         this.scheduledStartDate = scheduledStartDate;
@@ -118,6 +118,7 @@ public class RunningCrew extends BaseEntity {
     public void start(final Long memberId) {
         validateMemberIsHost(memberId);
         validateRunningCrewDoesNotStart();
+        status = ProgressionType.IN_PROGRESS;
         implementedStartDate = LocalDateTime.now();
     }
 
@@ -125,6 +126,7 @@ public class RunningCrew extends BaseEntity {
         validateMemberIsHost(memberId);
         validateRunningCrewStart();
         validateRunningCrewDoesNotEnd();
+        status = ProgressionType.COMPLETED;
         implementedEndDate = LocalDateTime.now();
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -153,6 +153,12 @@ public class RunningCrew extends BaseEntity {
         participants.accept(memberId);
     }
 
+    public void reject(final Long hostId, final Long memberId) {
+        validateMemberIsHost(hostId);
+        validateMemberIsNotHost(memberId);
+        participants.reject(memberId);
+    }
+
     private void initializeProgress() {
         final int number = participants.getNumberOrParticipants();
         if (number == 1 && status.isCreatedOrReady()) {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -126,9 +126,24 @@ public class RunningCrew extends BaseEntity {
         implementedEndDate = LocalDateTime.now();
     }
 
+    public void participate(final Long memberId) {
+        validateMemberIsNotHost(memberId);
+        participants.validateMemberIsNotParticipant(memberId);
+        participants.validateCapacityIsOver(capacity);
+        deadline.validateDeadlineIsNotOver();
+        validateRunningCrewStatusIsReady();
+        participants.add(this, memberId);
+    }
+
     private void validateMemberIsHost(final Long memberId) {
         if (!this.memberId.equals(memberId)) {
             throw new IllegalArgumentException(String.format("호스트가 아닙니다. [%s]", memberId));
+        }
+    }
+
+    private void validateMemberIsNotHost(final Long memberId) {
+        if (this.memberId.equals(memberId)) {
+            throw new IllegalArgumentException(String.format("러닝크루의 호스트입니다. [%s]", memberId));
         }
     }
 
@@ -155,6 +170,12 @@ public class RunningCrew extends BaseEntity {
     private void validateRunningCrewDoesNotEnd() {
         if (implementedEndDate != null) {
             throw new IllegalArgumentException(String.format("이미 종료되었습니다. [%s]", implementedEndDate));
+        }
+    }
+
+    private void validateRunningCrewStatusIsReady() {
+        if (!status.isReady()) {
+            throw new IllegalArgumentException(String.format("이미 시작되었습니다. [%s]", status.getName()));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -42,7 +42,7 @@ public class RunningCrew extends BaseEntity {
     private ProgressionType status;
 
     @Embedded
-    private Participants participant;
+    private Participants participants;
 
     @Embedded
     private Capacity capacity;
@@ -77,7 +77,7 @@ public class RunningCrew extends BaseEntity {
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
         this.status = ProgressionType.CREATED;
-        this.participant = new Participants(memberId);
+        this.participants = new Participants(this);
         this.capacity = capacity;
         this.scheduledStartDate = scheduledStartDate;
         this.scheduledEndDate = scheduledEndDate;
@@ -94,7 +94,7 @@ public class RunningCrew extends BaseEntity {
     ) {
         validateMemberIsHost(memberId);
         validateStartIsBeforeThanEnd(scheduledStartDate, scheduledEndDate);
-        this.participant.validateCapacityIsOver(capacity);
+        this.participants.validateCapacityIsOver(capacity);
 
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -1,8 +1,6 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
@@ -10,7 +8,6 @@ import org.locationtech.jts.io.WKTReader;
 
 import com.dobugs.yologaapi.domain.BaseEntity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -19,8 +16,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,9 +41,8 @@ public class RunningCrew extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private ProgressionType status;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "running_crew_id")
-    private List<Participant> participant = new ArrayList<>();
+    @Embedded
+    private Participants participant;
 
     @Embedded
     private Capacity capacity;
@@ -83,7 +77,7 @@ public class RunningCrew extends BaseEntity {
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
         this.status = ProgressionType.CREATED;
-        this.participant.add(new Participant(memberId));
+        this.participant = new Participants(memberId);
         this.capacity = capacity;
         this.scheduledStartDate = scheduledStartDate;
         this.scheduledEndDate = scheduledEndDate;
@@ -100,6 +94,8 @@ public class RunningCrew extends BaseEntity {
     ) {
         validateMemberIsHost(memberId);
         validateStartIsBeforeThanEnd(scheduledStartDate, scheduledEndDate);
+        this.participant.validateCapacityIsOver(capacity);
+
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
         this.capacity = capacity;

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -131,7 +131,7 @@ public class RunningCrew extends BaseEntity {
         participants.validateMemberIsNotParticipant(memberId);
         participants.validateCapacityIsOver(capacity);
         deadline.validateDeadlineIsNotOver();
-        validateRunningCrewStatusIsReady();
+        validateRunningCrewStatusIsCreatedOrReady();
         participants.add(this, memberId);
     }
 
@@ -139,6 +139,19 @@ public class RunningCrew extends BaseEntity {
         validateMemberIsNotHost(memberId);
         participants.validateMemberIsRequested(memberId);
         participants.delete(memberId);
+    }
+
+    public void withdraw(final Long memberId) {
+        validateMemberIsNotHost(memberId);
+        participants.withdraw(memberId);
+        initializeProgress();
+    }
+
+    private void initializeProgress() {
+        final int number = participants.getNumberOrParticipants();
+        if (number == 1 && status.isCreatedOrReady()) {
+            status = ProgressionType.CREATED;
+        }
     }
 
     private void validateMemberIsHost(final Long memberId) {
@@ -179,9 +192,9 @@ public class RunningCrew extends BaseEntity {
         }
     }
 
-    private void validateRunningCrewStatusIsReady() {
-        if (!status.isReady()) {
-            throw new IllegalArgumentException(String.format("이미 시작되었습니다. [%s]", status.getName()));
+    private void validateRunningCrewStatusIsCreatedOrReady() {
+        if (!status.isCreatedOrReady()) {
+            throw new IllegalArgumentException(String.format("이미 진행중이거나 완료되었습니다. [%s]", status.getName()));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -145,6 +145,14 @@ public class RunningCrew extends BaseEntity {
         initializeProgress();
     }
 
+    public void accept(final Long hostId, final Long memberId) {
+        validateMemberIsHost(hostId);
+        validateMemberIsNotHost(memberId);
+        deadline.validateDeadlineIsNotOver();
+        validateRunningCrewStatusIsCreatedOrReadyOrInProgress();
+        participants.accept(memberId);
+    }
+
     private void initializeProgress() {
         final int number = participants.getNumberOrParticipants();
         if (number == 1 && status.isCreatedOrReady()) {
@@ -193,6 +201,12 @@ public class RunningCrew extends BaseEntity {
     private void validateRunningCrewStatusIsCreatedOrReady() {
         if (!status.isCreatedOrReady()) {
             throw new IllegalArgumentException(String.format("이미 진행중이거나 완료되었습니다. [%s]", status.getName()));
+        }
+    }
+
+    private void validateRunningCrewStatusIsCreatedOrReadyOrInProgress() {
+        if (!status.isCreatedOrReadyOrInProgress()) {
+            throw new IllegalArgumentException(String.format("이미 완료되었습니다. [%s]", status.getName()));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/repository/ParticipantRepository.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/ParticipantRepository.java
@@ -1,0 +1,29 @@
+package com.dobugs.yologaapi.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.dobugs.yologaapi.domain.runningcrew.Participant;
+import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+    @Query(
+        value = "SELECT m.id AS id, m.nickname AS nickname\n"
+            + "FROM participant AS p\n"
+            + "LEFT JOIN member AS m\n"
+            + "ON p.member_id = m.id\n"
+            + "WHERE p.running_crew_id = ?1 AND p.status = ?2 AND p.archived = true\n"
+            + ";",
+        countQuery = "SELECT (p.id)\n"
+            + "FROM participant AS p\n"
+            + "LEFT JOIN member AS m\n"
+            + "ON p.member_id = m.id\n"
+            + "WHERE p.running_crew_id = ?1 AND p.status = ?2 AND p.archived = true\n"
+            + ";",
+        nativeQuery = true
+    )
+    List<ParticipantDto> findParticipants(final Long runningCrewId, final String participantType);
+}

--- a/src/main/java/com/dobugs/yologaapi/repository/dto/response/ParticipantDto.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/dto/response/ParticipantDto.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaapi.repository.dto.response;
+
+public interface ParticipantDto {
+
+    Long getId();
+
+    String getNickname();
+}

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -1,0 +1,33 @@
+package com.dobugs.yologaapi.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
+import com.dobugs.yologaapi.repository.RunningCrewRepository;
+import com.dobugs.yologaapi.support.TokenGenerator;
+import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ParticipationService {
+
+    private final RunningCrewRepository runningCrewRepository;
+    private final TokenGenerator tokenGenerator;
+
+    public void participate(final String serviceToken, final Long runningCrewId) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        savedRunningCrew.participate(memberId);
+    }
+
+    private RunningCrew findRunningCrewBy(final Long runningCrewId) {
+        return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
+            .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -50,6 +50,14 @@ public class ParticipationService {
         savedRunningCrew.accept(hostId, memberId);
     }
 
+    public void reject(final String serviceToken, final Long runningCrewId, final Long memberId) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long hostId = userTokenResponse.memberId();
+
+        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        savedRunningCrew.reject(hostId, memberId);
+    }
+
     private RunningCrew findRunningCrewBy(final Long runningCrewId) {
         return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -26,6 +26,14 @@ public class ParticipationService {
         savedRunningCrew.participate(memberId);
     }
 
+    public void cancel(final String serviceToken, final Long runningCrewId) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        savedRunningCrew.cancel(memberId);
+    }
+
     private RunningCrew findRunningCrewBy(final Long runningCrewId) {
         return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -42,6 +42,14 @@ public class ParticipationService {
         savedRunningCrew.withdraw(memberId);
     }
 
+    public void accept(final String serviceToken, final Long runningCrewId, final Long memberId) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long hostId = userTokenResponse.memberId();
+
+        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        savedRunningCrew.accept(hostId, memberId);
+    }
+
     private RunningCrew findRunningCrewBy(final Long runningCrewId) {
         return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -34,6 +34,14 @@ public class ParticipationService {
         savedRunningCrew.cancel(memberId);
     }
 
+    public void withdraw(final String serviceToken, final Long runningCrewId) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        savedRunningCrew.withdraw(memberId);
+    }
+
     private RunningCrew findRunningCrewBy(final Long runningCrewId) {
         return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -1,10 +1,17 @@
 package com.dobugs.yologaapi.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
+import com.dobugs.yologaapi.repository.ParticipantRepository;
 import com.dobugs.yologaapi.repository.RunningCrewRepository;
+import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
+import com.dobugs.yologaapi.service.dto.response.ParticipantResponse;
+import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.dobugs.yologaapi.support.TokenGenerator;
 import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
 
@@ -16,7 +23,18 @@ import lombok.RequiredArgsConstructor;
 public class ParticipationService {
 
     private final RunningCrewRepository runningCrewRepository;
+    private final ParticipantRepository participantRepository;
     private final TokenGenerator tokenGenerator;
+
+    @Transactional(readOnly = true)
+    public ParticipantsResponse findParticipants(final Long runningCrewId) {
+        final List<ParticipantDto> response = participantRepository.findParticipants(runningCrewId, ParticipantType.PARTICIPATING.getSavedName());
+        return new ParticipantsResponse(
+            response.stream()
+                .map(participant -> new ParticipantResponse(participant.getId(), participant.getNickname()))
+                .toList()
+        );
+    }
 
     public void participate(final String serviceToken, final Long runningCrewId) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/ParticipantResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/ParticipantResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaapi.service.dto.response;
+
+public record ParticipantResponse(Long id, String nickname) {
+}

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/ParticipantsResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/ParticipantsResponse.java
@@ -1,0 +1,6 @@
+package com.dobugs.yologaapi.service.dto.response;
+
+import java.util.List;
+
+public record ParticipantsResponse(List<ParticipantResponse> participants) {
+}

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -90,4 +90,22 @@ class ParticipationControllerTest {
             )
         ;
     }
+
+    @DisplayName("러닝크루 참여 요청을 승인한다")
+    @Test
+    void accept() throws Exception {
+        final String accessToken = "accessToken";
+        final long runningCrewId = 1L;
+        final long memberId = 1L;
+
+        mockMvc.perform(post(BASIC_URL + "/" + runningCrewId + "/accept/" + memberId)
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/accept",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -108,4 +108,22 @@ class ParticipationControllerTest {
             )
         ;
     }
+
+    @DisplayName("러닝크루 참여 요청을 거절한다")
+    @Test
+    void reject() throws Exception {
+        final String accessToken = "accessToken";
+        final long runningCrewId = 1L;
+        final long memberId = 1L;
+
+        mockMvc.perform(post(BASIC_URL + "/" + runningCrewId + "/reject/" + memberId)
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/reject",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -73,4 +73,21 @@ class ParticipationControllerTest {
             )
         ;
     }
+
+    @DisplayName("러닝크루에 탈퇴한다")
+    @Test
+    void withdraw() throws Exception {
+        final String accessToken = "accessToken";
+        final long runningCrewId = 1L;
+
+        mockMvc.perform(post(BASIC_URL + "/" + runningCrewId + "/withdraw")
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/withdraw",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -1,11 +1,15 @@
 package com.dobugs.yologaapi.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +24,8 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.dobugs.yologaapi.service.ParticipationService;
+import com.dobugs.yologaapi.service.dto.response.ParticipantResponse;
+import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @AutoConfigureMockMvc
@@ -39,6 +45,27 @@ class ParticipationControllerTest {
 
     @MockBean
     private ParticipationService participationService;
+
+    @DisplayName("러닝크루 참여자 목록 정보를 조회한다")
+    @Test
+    void findParticipants() throws Exception {
+        final long runningCrewId = 1L;
+
+        final ParticipantResponse participant1 = new ParticipantResponse(1L, "유콩");
+        final ParticipantResponse participant2 = new ParticipantResponse(2L, "건");
+        final ParticipantsResponse response = new ParticipantsResponse(List.of(participant1, participant2));
+
+        given(participationService.findParticipants(runningCrewId)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/" + runningCrewId + "/participants"))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/findParticipants",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 
     @DisplayName("러닝크루에 참여 요청을 한다")
     @Test

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -40,7 +40,7 @@ class ParticipationControllerTest {
     @MockBean
     private ParticipationService participationService;
 
-    @DisplayName("러닝크루에 참여 요청읋 한다")
+    @DisplayName("러닝크루에 참여 요청을 한다")
     @Test
     void participate() throws Exception {
         final String accessToken = "accessToken";
@@ -51,6 +51,23 @@ class ParticipationControllerTest {
             .andExpect(status().isOk())
             .andDo(document(
                 "participation/participate",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("러닝크루에 참여 요청을 취소한다")
+    @Test
+    void cancel() throws Exception {
+        final String accessToken = "accessToken";
+        final long runningCrewId = 1L;
+
+        mockMvc.perform(post(BASIC_URL + "/" + runningCrewId + "/cancel")
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/cancel",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -1,0 +1,59 @@
+package com.dobugs.yologaapi.controller;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaapi.service.ParticipationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WebMvcTest(ParticipationController.class)
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+@DisplayName("Participation 컨트롤러 테스트")
+class ParticipationControllerTest {
+
+    private static final String BASIC_URL = "/api/v1/running-crews";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ParticipationService participationService;
+
+    @DisplayName("러닝크루에 참여 요청읋 한다")
+    @Test
+    void participate() throws Exception {
+        final String accessToken = "accessToken";
+        final long runningCrewId = 1L;
+
+        mockMvc.perform(post(BASIC_URL + "/" + runningCrewId + "/participate")
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "participation/participate",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/CapacityTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/CapacityTest.java
@@ -1,21 +1,54 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Capacity 도메인 테스트")
 class CapacityTest {
 
-    @DisplayName("Capacity 의 값은 기준치 보다 커야 한다")
-    @ParameterizedTest
-    @ValueSource(ints = {-1, 0, 1})
-    void capacityShouldOverStandard(int value) {
-        assertThatThrownBy(() -> new Capacity(value))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("인원은")
-            .hasMessageContaining("명이어야 합니다.");
+    @DisplayName("수용인원이 남았는지에 대한 테스트")
+    @Nested
+    public class isLeft {
+
+        private static final int VALUE = 5;
+
+        @DisplayName("수용인원이 남았을 경우 true 를 반환한다")
+        @Test
+        void capacityIsLeft() {
+            final int numberOfParticipants = 1;
+            final Capacity capacity = new Capacity(VALUE);
+
+            assertThat(capacity.isLeft(numberOfParticipants)).isTrue();
+        }
+
+        @DisplayName("수용인원이 남지 않았을 경우 false 를 반환한다")
+        @ParameterizedTest
+        @ValueSource(ints = {VALUE, VALUE + 1})
+        void capacityIsFull(final int numberOfParticipants) {
+            final Capacity capacity = new Capacity(VALUE);
+
+            assertThat(capacity.isLeft(numberOfParticipants)).isFalse();
+        }
+    }
+
+    @DisplayName("Capacity 의 최저 인원 테스트")
+    @Nested
+    public class validateCapacityIsOverStandard {
+
+        @DisplayName("Capacity 의 값은 기준치 보다 커야 한다")
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 0, 1})
+        void capacityShouldOverStandard(int value) {
+            assertThatThrownBy(() -> new Capacity(value))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("인원은")
+                .hasMessageContaining("명이어야 합니다.");
+        }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/DeadlineTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/DeadlineTest.java
@@ -1,23 +1,67 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Deadline 도메인 테스트")
 class DeadlineTest {
 
-    @DisplayName("마감 기한은 현재 시간보다 이후여야 한다")
-    @Test
-    void deadlineShouldAfterThanNow() {
-        final LocalDateTime now = LocalDateTime.now();
-        final LocalDateTime deadline = now.minusDays(1);
+    @DisplayName("Deadline 객체 생성 테스트")
+    @Nested
+    public class create {
 
-        assertThatThrownBy(() -> new Deadline(deadline))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("마감 기한이 현재 시간보다 이전입니다.");
+        @DisplayName("Deadline 객체를 생성한다")
+        @Test
+        void success() {
+            final LocalDateTime deadline = LocalDateTime.now().plusDays(1);
+
+            assertThatCode(() -> new Deadline(deadline))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("마감 기한은 현재 시간보다 이후여야 한다")
+        @Test
+        void deadlineShouldAfterThanNow() {
+            final LocalDateTime now = LocalDateTime.now();
+            final LocalDateTime deadline = now.minusDays(1);
+
+            assertThatThrownBy(() -> new Deadline(deadline))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("마감 기한이 현재 시간보다 이전입니다.");
+        }
+    }
+
+    @DisplayName("마감 기한 테스트")
+    @Nested
+    public class validateDeadlineIsNotOver {
+
+        @DisplayName("마감 기한이 지나지 않았으면 예외가 발생하지 않는다")
+        @Test
+        void deadlineIsNotOver() {
+            final Deadline deadline = new Deadline(LocalDateTime.now().plusDays(1));
+
+            assertThatCode(deadline::validateDeadlineIsNotOver)
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("마감 기한이 지났으면 예외가 발생한다")
+        @Test
+        void deadlineIsOver() throws InterruptedException {
+            final int seconds = 1;
+            final Deadline deadline = new Deadline(LocalDateTime.now().plusSeconds(seconds));
+
+            TimeUnit.SECONDS.sleep(seconds);
+
+            assertThatThrownBy(deadline::validateDeadlineIsNotOver)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("마감기한이 지났습니다.");
+        }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -26,29 +26,47 @@ class ParticipantTest {
     @Nested
     public class create {
 
-        @DisplayName("호스트 객체를 생성한다")
-        @Test
-        void memberIsHost() {
-            final Participant host = Participant.host(runningCrew);
-
-            assertAll(
-                () -> assertThat(host.getMemberId()).isEqualTo(HOST_ID),
-                () -> assertThat(host.getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
-                () -> assertThat(host.getRunningCrew()).isEqualTo(runningCrew)
-            );
-        }
-
         @DisplayName("참여자 객체를 생성한다")
         @Test
         void memberIsParticipant() {
             final long memberId = 1L;
-            final Participant member = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.requested(runningCrew, memberId);
 
             assertAll(
                 () -> assertThat(member.getMemberId()).isEqualTo(memberId),
                 () -> assertThat(member.getStatus()).isEqualTo(ParticipantType.REQUESTED),
                 () -> assertThat(member.getRunningCrew()).isEqualTo(runningCrew)
             );
+        }
+    }
+
+    @DisplayName("참여 테스트")
+    @Nested
+    public class participate {
+
+        @DisplayName("참여한다")
+        @Test
+        void success() {
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
+
+            member.participate();
+
+            assertThat(member.getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
+        }
+
+        @DisplayName("참여 요청중이 아니면 예외가 발생한다")
+        @Test
+        void memberIsNotRequested() {
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
+
+            member.participate();
+            member.withdraw();
+
+            assertThatThrownBy(member::participate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여 요청인 상태가 아닙니다.");
         }
     }
 
@@ -60,7 +78,7 @@ class ParticipantTest {
         @Test
         void success() {
             final long memberId = 1L;
-            final Participant member = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.requested(runningCrew, memberId);
 
             member.cancel();
 
@@ -70,9 +88,13 @@ class ParticipantTest {
         @DisplayName("참여 요청중이 아니면 예외가 발생한다")
         @Test
         void memberIsNotRequested() {
-            final Participant participant = Participant.host(runningCrew);
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
 
-            assertThatThrownBy(participant::cancel)
+            member.participate();
+            member.withdraw();
+
+            assertThatThrownBy(member::cancel)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여 요청인 상태가 아닙니다.");
         }
@@ -85,18 +107,20 @@ class ParticipantTest {
         @DisplayName("탈퇴한다")
         @Test
         void success() {
-            final Participant participant = Participant.host(runningCrew);
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
+            member.participate();
 
-            participant.withdraw();
+            member.withdraw();
 
-            assertThat(participant.getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
+            assertThat(member.getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
         }
 
         @DisplayName("참여중이 아니면 예외가 발생한다")
         @Test
         void memberIsNotParticipating() {
             final long memberId = 1L;
-            final Participant member = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.requested(runningCrew, memberId);
 
             assertThatThrownBy(member::withdraw)
                 .isInstanceOf(IllegalArgumentException.class)
@@ -112,7 +136,7 @@ class ParticipantTest {
         @Test
         void success() {
             final long memberId = 1L;
-            final Participant member = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.requested(runningCrew, memberId);
 
             member.accept();
 
@@ -122,7 +146,11 @@ class ParticipantTest {
         @DisplayName("참여 요청중이 아니면 예외가 발생한다")
         @Test
         void memberIsNotRequested() {
-            final Participant member = Participant.host(runningCrew);
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
+
+            member.participate();
+            member.withdraw();
 
             assertThatThrownBy(member::accept)
                 .isInstanceOf(IllegalArgumentException.class)
@@ -138,7 +166,7 @@ class ParticipantTest {
         @Test
         void success() {
             final long memberId = 1L;
-            final Participant member = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.requested(runningCrew, memberId);
 
             member.reject();
 
@@ -148,7 +176,11 @@ class ParticipantTest {
         @DisplayName("참여 요청중이 아니면 예외가 발생한다")
         @Test
         void memberIsNotRequested() {
-            final Participant member = Participant.host(runningCrew);
+            final long memberId = 1L;
+            final Participant member = Participant.requested(runningCrew, memberId);
+
+            member.participate();
+            member.withdraw();
 
             assertThatThrownBy(member::reject)
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -29,12 +29,12 @@ class ParticipantTest {
         @DisplayName("호스트 객체를 생성한다")
         @Test
         void memberIsHost() {
-            final Participant participant = new Participant(runningCrew);
+            final Participant host = Participant.host(runningCrew);
 
             assertAll(
-                () -> assertThat(participant.getMemberId()).isEqualTo(HOST_ID),
-                () -> assertThat(participant.getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
-                () -> assertThat(participant.getRunningCrew()).isEqualTo(runningCrew)
+                () -> assertThat(host.getMemberId()).isEqualTo(HOST_ID),
+                () -> assertThat(host.getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
+                () -> assertThat(host.getRunningCrew()).isEqualTo(runningCrew)
             );
         }
 
@@ -42,12 +42,12 @@ class ParticipantTest {
         @Test
         void memberIsParticipant() {
             final long memberId = 1L;
-            final Participant participant = new Participant(memberId, runningCrew);
+            final Participant member = Participant.member(runningCrew, memberId);
 
             assertAll(
-                () -> assertThat(participant.getMemberId()).isEqualTo(memberId),
-                () -> assertThat(participant.getStatus()).isEqualTo(ParticipantType.REQUESTED),
-                () -> assertThat(participant.getRunningCrew()).isEqualTo(runningCrew)
+                () -> assertThat(member.getMemberId()).isEqualTo(memberId),
+                () -> assertThat(member.getStatus()).isEqualTo(ParticipantType.REQUESTED),
+                () -> assertThat(member.getRunningCrew()).isEqualTo(runningCrew)
             );
         }
     }
@@ -59,7 +59,7 @@ class ParticipantTest {
         @DisplayName("탈퇴한다")
         @Test
         void success() {
-            final Participant participant = new Participant(runningCrew);
+            final Participant participant = Participant.host(runningCrew);
 
             participant.withdraw();
 
@@ -70,9 +70,9 @@ class ParticipantTest {
         @Test
         void memberIsNotParticipating() {
             final long memberId = 1L;
-            final Participant participant = new Participant(memberId, runningCrew);
+            final Participant member = Participant.member(runningCrew, memberId);
 
-            assertThatThrownBy(participant::withdraw)
+            assertThatThrownBy(member::withdraw)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여중인 상태가 아닙니다.");
         }
@@ -86,7 +86,7 @@ class ParticipantTest {
         @Test
         void memberIsRequested() {
             final long memberId = 1L;
-            final Participant participant = new Participant(memberId, runningCrew);
+            final Participant participant = Participant.member(runningCrew, memberId);
 
             final boolean requested = participant.isRequested();
 
@@ -96,7 +96,7 @@ class ParticipantTest {
         @DisplayName("요청 중이 아닐 경우 false 를 반환한다")
         @Test
         void memberIsNotRequested() {
-            final Participant participant = new Participant(runningCrew);
+            final Participant participant = Participant.host(runningCrew);
 
             final boolean requested = participant.isRequested();
 

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaapi.domain.runningcrew;
 
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrew;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -51,13 +52,39 @@ class ParticipantTest {
         }
     }
 
+    @DisplayName("탈퇴 테스트")
+    @Nested
+    public class withdraw {
+
+        @DisplayName("탈퇴한다")
+        @Test
+        void success() {
+            final Participant participant = new Participant(runningCrew);
+
+            participant.withdraw();
+
+            assertThat(participant.getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
+        }
+
+        @DisplayName("참여중이 아니면 예외가 발생한다")
+        @Test
+        void memberIsNotParticipating() {
+            final long memberId = 1L;
+            final Participant participant = new Participant(memberId, runningCrew);
+
+            assertThatThrownBy(participant::withdraw)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여중인 상태가 아닙니다.");
+        }
+    }
+
     @DisplayName("요청 중인지에 대한 테스트")
     @Nested
     public class isRequested {
 
         @DisplayName("요청 중일 경우 true 를 반환한다")
         @Test
-        void participantTypeIsRequested() {
+        void memberIsRequested() {
             final long memberId = 1L;
             final Participant participant = new Participant(memberId, runningCrew);
 
@@ -68,7 +95,7 @@ class ParticipantTest {
 
         @DisplayName("요청 중이 아닐 경우 false 를 반환한다")
         @Test
-        void participantTypeIsNotRequested() {
+        void memberIsNotRequested() {
             final Participant participant = new Participant(runningCrew);
 
             final boolean requested = participant.isRequested();

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -129,4 +129,30 @@ class ParticipantTest {
                 .hasMessageContaining("참여 요청인 상태가 아닙니다.");
         }
     }
+
+    @DisplayName("참여 요청 거절 테스트")
+    @Nested
+    public class reject {
+
+        @DisplayName("참여 요청을 거절한다")
+        @Test
+        void success() {
+            final long memberId = 1L;
+            final Participant member = Participant.member(runningCrew, memberId);
+
+            member.reject();
+
+            assertThat(member.getStatus()).isEqualTo(ParticipantType.REJECTED);
+        }
+
+        @DisplayName("참여 요청중이 아니면 예외가 발생한다")
+        @Test
+        void memberIsNotRequested() {
+            final Participant member = Participant.host(runningCrew);
+
+            assertThatThrownBy(member::reject)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여 요청인 상태가 아닙니다.");
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -1,0 +1,79 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrew;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Participant 도메인 테스트")
+class ParticipantTest {
+
+    private static final Long HOST_ID = 0L;
+
+    private RunningCrew runningCrew;
+
+    @BeforeEach
+    void setUp() {
+        runningCrew = createRunningCrew(HOST_ID);
+    }
+
+    @DisplayName("Participant 객체 생성 테스트")
+    @Nested
+    public class create {
+
+        @DisplayName("호스트 객체를 생성한다")
+        @Test
+        void memberIsHost() {
+            final Participant participant = new Participant(runningCrew);
+
+            assertAll(
+                () -> assertThat(participant.getMemberId()).isEqualTo(HOST_ID),
+                () -> assertThat(participant.getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
+                () -> assertThat(participant.getRunningCrew()).isEqualTo(runningCrew)
+            );
+        }
+
+        @DisplayName("참여자 객체를 생성한다")
+        @Test
+        void memberIsParticipant() {
+            final long memberId = 1L;
+            final Participant participant = new Participant(memberId, runningCrew);
+
+            assertAll(
+                () -> assertThat(participant.getMemberId()).isEqualTo(memberId),
+                () -> assertThat(participant.getStatus()).isEqualTo(ParticipantType.REQUESTED),
+                () -> assertThat(participant.getRunningCrew()).isEqualTo(runningCrew)
+            );
+        }
+    }
+
+    @DisplayName("요청 중인지에 대한 테스트")
+    @Nested
+    public class isRequested {
+
+        @DisplayName("요청 중일 경우 true 를 반환한다")
+        @Test
+        void participantTypeIsRequested() {
+            final long memberId = 1L;
+            final Participant participant = new Participant(memberId, runningCrew);
+
+            final boolean requested = participant.isRequested();
+
+            assertThat(requested).isTrue();
+        }
+
+        @DisplayName("요청 중이 아닐 경우 false 를 반환한다")
+        @Test
+        void participantTypeIsNotRequested() {
+            final Participant participant = new Participant(runningCrew);
+
+            final boolean requested = participant.isRequested();
+
+            assertThat(requested).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -52,6 +52,32 @@ class ParticipantTest {
         }
     }
 
+    @DisplayName("참여 요청 취소 테스트")
+    @Nested
+    public class cancel {
+
+        @DisplayName("참여 요청했던 것을 취소한다")
+        @Test
+        void success() {
+            final long memberId = 1L;
+            final Participant member = Participant.member(runningCrew, memberId);
+
+            member.cancel();
+
+            assertThat(member.getStatus()).isEqualTo(ParticipantType.CANCELLED);
+        }
+
+        @DisplayName("참여 요청중이 아니면 예외가 발생한다")
+        @Test
+        void memberIsNotRequested() {
+            final Participant participant = Participant.host(runningCrew);
+
+            assertThatThrownBy(participant::cancel)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여 요청인 상태가 아닙니다.");
+        }
+    }
+
     @DisplayName("탈퇴 테스트")
     @Nested
     public class withdraw {

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTest.java
@@ -104,29 +104,29 @@ class ParticipantTest {
         }
     }
 
-    @DisplayName("요청 중인지에 대한 테스트")
+    @DisplayName("참여 요청 승인 테스트")
     @Nested
-    public class isRequested {
+    public class accept {
 
-        @DisplayName("요청 중일 경우 true 를 반환한다")
+        @DisplayName("참여 요청을 승인한다")
         @Test
-        void memberIsRequested() {
+        void success() {
             final long memberId = 1L;
-            final Participant participant = Participant.member(runningCrew, memberId);
+            final Participant member = Participant.member(runningCrew, memberId);
 
-            final boolean requested = participant.isRequested();
+            member.accept();
 
-            assertThat(requested).isTrue();
+            assertThat(member.getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
         }
 
-        @DisplayName("요청 중이 아닐 경우 false 를 반환한다")
+        @DisplayName("참여 요청중이 아니면 예외가 발생한다")
         @Test
         void memberIsNotRequested() {
-            final Participant participant = Participant.host(runningCrew);
+            final Participant member = Participant.host(runningCrew);
 
-            final boolean requested = participant.isRequested();
-
-            assertThat(requested).isFalse();
+            assertThatThrownBy(member::accept)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여 요청인 상태가 아닙니다.");
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTypeTest.java
@@ -1,0 +1,33 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ParticipantType 도메인 테스트")
+class ParticipantTypeTest {
+
+    @DisplayName("요청 중인지에 대한 테스트")
+    @Nested
+    public class isRequested {
+
+        @DisplayName("요청 중일 경우 true 를 반환한다")
+        @Test
+        void participantTypeIsRequested() {
+            assertThat(ParticipantType.REQUESTED.isRequested()).isTrue();
+        }
+
+        @DisplayName("요청 중이 아닐 경우 false 를 반환한다")
+        @Test
+        void participantTypeIsNotRequested() {
+            assertAll(
+                () -> assertThat(ParticipantType.PARTICIPATING.isRequested()).isFalse(),
+                () -> assertThat(ParticipantType.REJECTED.isRequested()).isFalse(),
+                () -> assertThat(ParticipantType.WITHDRAWN.isRequested()).isFalse()
+            );
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantTypeTest.java
@@ -30,4 +30,25 @@ class ParticipantTypeTest {
             );
         }
     }
+
+    @DisplayName("참여중인지에 대한 테스트")
+    @Nested
+    public class isParticipating {
+
+        @DisplayName("참여중일 경우 true 를 반환한다")
+        @Test
+        void participantTypeIsParticipating() {
+            assertThat(ParticipantType.PARTICIPATING.isParticipating()).isTrue();
+        }
+
+        @DisplayName("참여중이 아닐 경우 false 를 반환한다")
+        @Test
+        void participantTypeIsNotParticipating() {
+            assertAll(
+                () -> assertThat(ParticipantType.REQUESTED.isParticipating()).isFalse(),
+                () -> assertThat(ParticipantType.REJECTED.isParticipating()).isFalse(),
+                () -> assertThat(ParticipantType.WITHDRAWN.isParticipating()).isFalse()
+            );
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,10 +68,11 @@ class ParticipantsTest {
 
             participants.cancel(memberId);
 
-            final Participant participant = participants.getValue().stream()
+            final Optional<Participant> participant = participants.getValue().stream()
                 .filter(value -> value.getMemberId().equals(memberId))
-                .findFirst().get();
-            assertThat(participant.getStatus()).isEqualTo(ParticipantType.CANCELLED);
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.CANCELLED);
         }
 
         @DisplayName("참여자가 아닐 경우 예외가 발생한다")
@@ -96,10 +98,11 @@ class ParticipantsTest {
 
             participants.withdraw(HOST_ID);
 
-            final Participant participant = participants.getValue().stream()
+            final Optional<Participant> participant = participants.getValue().stream()
                 .filter(value -> value.getMemberId().equals(HOST_ID))
-                .findFirst().get();
-            assertThat(participant.getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
         }
 
         @DisplayName("참여자가 아닐 경우 예외가 발생한다")

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -37,11 +37,11 @@ class ParticipantsTest {
 
             participants.temporaryJoin(runningCrew, memberId);
 
-            final List<Long> idsOfParticipants = participants.getValue()
-                .stream()
-                .map(Participant::getMemberId)
-                .toList();
-            assertThat(idsOfParticipants).contains(memberId);
+            final Optional<Participant> participant = participants.getValue().stream()
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.REQUESTED);
         }
 
         @DisplayName("이미 존재하는 사용자를 추가하면 예외가 발생한다")
@@ -94,12 +94,15 @@ class ParticipantsTest {
         @DisplayName("탈퇴한다")
         @Test
         void success() {
+            final long memberId = 2L;
             final Participants participants = new Participants(runningCrew);
+            participants.temporaryJoin(runningCrew, memberId);
+            participants.accept(memberId);
 
-            participants.withdraw(HOST_ID);
+            participants.withdraw(memberId);
 
             final Optional<Participant> participant = participants.getValue().stream()
-                .filter(value -> value.getMemberId().equals(HOST_ID))
+                .filter(value -> value.getMemberId().equals(memberId))
                 .findFirst();
             assertThat(participant).isPresent();
             assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.WITHDRAWN);

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -72,4 +72,29 @@ class ParticipantsTest {
                 .hasMessageContaining("참여자 수용인원이 다 찼습니다.");
         }
     }
+
+    @DisplayName("참여자인지 검증 테스트")
+    @Nested
+    public class validateMemberIsNotParticipant {
+
+        @DisplayName("참여자가 아닐 경우 예외가 발생하지 않는다")
+        @Test
+        void memberIsNotParticipant() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+
+            assertThatCode(() -> participants.validateMemberIsNotParticipant(memberId))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("참여자일 경우 예외가 발생한다")
+        @Test
+        void memberIsParticipant() {
+            final Participants participants = new Participants(runningCrew);
+
+            assertThatThrownBy(() -> participants.validateMemberIsNotParticipant(HOST_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("이미 참여중입니다.");
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -67,11 +67,10 @@ class ParticipantsTest {
 
             participants.cancel(memberId);
 
-            final List<Long> idsOfParticipants = participants.getValue()
-                .stream()
-                .map(Participant::getMemberId)
-                .toList();
-            assertThat(idsOfParticipants).doesNotContain(memberId);
+            final Participant participant = participants.getValue().stream()
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst().get();
+            assertThat(participant.getStatus()).isEqualTo(ParticipantType.CANCELLED);
         }
 
         @DisplayName("참여자가 아닐 경우 예외가 발생한다")

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -24,9 +24,9 @@ class ParticipantsTest {
         runningCrew = createRunningCrew(HOST_ID);
     }
 
-    @DisplayName("참여자 추가 테스트")
+    @DisplayName("참여자 요청 추가 테스트")
     @Nested
-    public class add {
+    public class temporaryJoin {
 
         @DisplayName("참여자를 추가한다")
         @Test
@@ -34,7 +34,7 @@ class ParticipantsTest {
             final long memberId = 2L;
             final Participants participants = new Participants(runningCrew);
 
-            participants.add(runningCrew, memberId);
+            participants.temporaryJoin(runningCrew, memberId);
 
             final List<Long> idsOfParticipants = participants.getValue()
                 .stream()
@@ -48,24 +48,24 @@ class ParticipantsTest {
         void memberIsAlreadyParticipant() {
             final Participants participants = new Participants(runningCrew);
 
-            assertThatThrownBy(() -> participants.add(runningCrew, HOST_ID))
+            assertThatThrownBy(() -> participants.temporaryJoin(runningCrew, HOST_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("이미 참여중입니다.");
         }
     }
 
-    @DisplayName("참여자 삭제 테스트")
+    @DisplayName("참여자 요청 취소 테스트")
     @Nested
-    public class delete {
+    public class cancel {
 
-        @DisplayName("참여자를 삭제한다")
+        @DisplayName("참여자 요청을 취소한다")
         @Test
         void success() {
             final long memberId = 2L;
             final Participants participants = new Participants(runningCrew);
-            participants.add(runningCrew, memberId);
+            participants.temporaryJoin(runningCrew, memberId);
 
-            participants.delete(memberId);
+            participants.cancel(memberId);
 
             final List<Long> idsOfParticipants = participants.getValue()
                 .stream()
@@ -80,7 +80,7 @@ class ParticipantsTest {
             final long memberId = 2L;
             final Participants participants = new Participants(runningCrew);
 
-            assertThatThrownBy(() -> participants.delete(memberId))
+            assertThatThrownBy(() -> participants.cancel(memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여자가 아닙니다.");
         }
@@ -134,74 +134,12 @@ class ParticipantsTest {
         void capacityIsLower() {
             final Capacity capacity = new Capacity(2);
             final Participants participants = new Participants(runningCrew);
-            participants.add(runningCrew, 2L);
-            participants.add(runningCrew, 3L);
+            participants.temporaryJoin(runningCrew, 2L);
+            participants.temporaryJoin(runningCrew, 3L);
 
             assertThatThrownBy(() -> participants.validateCapacityIsOver(capacity))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여자 수용인원이 다 찼습니다.");
-        }
-    }
-
-    @DisplayName("참여자가 아닌 것에 대한 테스트")
-    @Nested
-    public class validateMemberIsNotParticipant {
-
-        @DisplayName("참여자가 아닐 경우 예외가 발생하지 않는다")
-        @Test
-        void memberIsNotParticipant() {
-            final long memberId = 2L;
-            final Participants participants = new Participants(runningCrew);
-
-            assertThatCode(() -> participants.validateMemberIsNotParticipant(memberId))
-                .doesNotThrowAnyException();
-        }
-
-        @DisplayName("참여자일 경우 예외가 발생한다")
-        @Test
-        void memberIsParticipant() {
-            final Participants participants = new Participants(runningCrew);
-
-            assertThatThrownBy(() -> participants.validateMemberIsNotParticipant(HOST_ID))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("이미 참여중입니다.");
-        }
-    }
-
-    @DisplayName("사용자가 참여 요청을 했었지에 대한 검증 테스트")
-    @Nested
-    public class validateMemberIsRequested {
-
-        @DisplayName("이전에 참여 요청을 했었으면 예외가 발생하지 않는다")
-        @Test
-        void memberIsRequested() {
-            final long memberId = 2L;
-            final Participants participants = new Participants(runningCrew);
-            participants.add(runningCrew, memberId);
-
-            assertThatCode(() -> participants.validateMemberIsRequested(memberId))
-                .doesNotThrowAnyException();
-        }
-
-        @DisplayName("참여 요청이 아닌 다른 상태값이면 예외가 발생한다")
-        @Test
-        void memberIsNotRequested() {
-            final Participants participants = new Participants(runningCrew);
-
-            assertThatThrownBy(() -> participants.validateMemberIsRequested(HOST_ID))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("참여 요청인 상태가 아닙니다.");
-        }
-
-        @DisplayName("참여자가 아닐 경우 예외가 발생한다")
-        @Test
-        void memberIsNotParticipant() {
-            final long memberId = 2L;
-            final Participants participants = new Participants(runningCrew);
-
-            assertThatThrownBy(() -> participants.validateMemberIsRequested(memberId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("참여자가 아닙니다.");
         }
     }
 
@@ -213,8 +151,8 @@ class ParticipantsTest {
         @Test
         void success() {
             final Participants participants = new Participants(runningCrew);
-            participants.add(runningCrew, 2L);
-            participants.add(runningCrew, 3L);
+            participants.temporaryJoin(runningCrew, 2L);
+            participants.temporaryJoin(runningCrew, 3L);
 
             final int numberOrParticipants = participants.getNumberOrParticipants();
 

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -149,6 +149,38 @@ class ParticipantsTest {
         }
     }
 
+    @DisplayName("참여 요청 거절 테스트")
+    @Nested
+    public class reject {
+
+        @DisplayName("참여 요청을 거절한다")
+        @Test
+        void success() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+            participants.temporaryJoin(runningCrew, memberId);
+
+            participants.reject(memberId);
+
+            final Optional<Participant> participant = participants.getValue().stream()
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.REJECTED);
+        }
+
+        @DisplayName("참여자가 아닐 경우 예외가 발생한다")
+        @Test
+        void memberIsNotParticipant() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+
+            assertThatThrownBy(() -> participants.reject(memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여자가 아닙니다.");
+        }
+    }
+
     @DisplayName("인원수가 더 많은 지에 대한 테스트")
     @Nested
     public class validateCapacityIsOver {

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -117,6 +117,38 @@ class ParticipantsTest {
         }
     }
 
+    @DisplayName("참여 요청 승인 테스트")
+    @Nested
+    public class accept {
+
+        @DisplayName("참여 요청을 승인한다")
+        @Test
+        void success() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+            participants.temporaryJoin(runningCrew, memberId);
+
+            participants.accept(memberId);
+
+            final Optional<Participant> participant = participants.getValue().stream()
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
+        }
+
+        @DisplayName("참여자가 아닐 경우 예외가 발생한다")
+        @Test
+        void memberIsNotParticipant() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+
+            assertThatThrownBy(() -> participants.accept(memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여자가 아닙니다.");
+        }
+    }
+
     @DisplayName("인원수가 더 많은 지에 대한 테스트")
     @Nested
     public class validateCapacityIsOver {

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -1,14 +1,25 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrew;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Participants 도메인 테스트")
 class ParticipantsTest {
+
+    private static final long HOST_ID = 1L;
+
+    private RunningCrew runningCrew;
+
+    @BeforeEach
+    void setUp() {
+        runningCrew = createRunningCrew(HOST_ID);
+    }
 
     @DisplayName("참여자 추가 테스트")
     @Nested
@@ -17,19 +28,18 @@ class ParticipantsTest {
         @DisplayName("참여자를 추가한다")
         @Test
         void success() {
-            final Participants participants = new Participants(1L);
+            final Participants participants = new Participants(runningCrew);
 
-            assertThatCode(() -> participants.add(2L))
+            assertThatCode(() -> participants.add(runningCrew, 2L))
                 .doesNotThrowAnyException();
         }
 
         @DisplayName("이미 존재하는 사용자를 추가하면 예외가 발생한다")
         @Test
         void memberIsAlreadyParticipant() {
-            final long memberId = 1L;
-            final Participants participants = new Participants(memberId);
+            final Participants participants = new Participants(runningCrew);
 
-            assertThatThrownBy(() -> participants.add(memberId))
+            assertThatThrownBy(() -> participants.add(runningCrew, HOST_ID))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("이미 참여된 사용자입니다.");
         }
@@ -38,24 +48,24 @@ class ParticipantsTest {
     @DisplayName("인원수가 더 많은 지에 대한 테스트")
     @Nested
     public class validateCapacityIsOver {
-        
+
         @DisplayName("참여자보다 인원 수가 더 많을 경우 예외가 발생하지 않는다")
         @Test
         void capacityIsOver() {
             final Capacity capacity = new Capacity(5);
-            final Participants participants = new Participants(1L);
+            final Participants participants = new Participants(runningCrew);
 
             assertThatCode(() -> participants.validateCapacityIsOver(capacity))
                 .doesNotThrowAnyException();
         }
-        
+
         @DisplayName("참여자보다 인원 수가 더 적을 경우 예외가 발생한다")
         @Test
         void capacityIsLower() {
             final Capacity capacity = new Capacity(2);
-            final Participants participants = new Participants(1L);
-            participants.add(2L);
-            participants.add(3L);
+            final Participants participants = new Participants(runningCrew);
+            participants.add(runningCrew, 2L);
+            participants.add(runningCrew, 3L);
 
             assertThatThrownBy(() -> participants.validateCapacityIsOver(capacity))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -1,0 +1,65 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Participants 도메인 테스트")
+class ParticipantsTest {
+
+    @DisplayName("참여자 추가 테스트")
+    @Nested
+    public class add {
+
+        @DisplayName("참여자를 추가한다")
+        @Test
+        void success() {
+            final Participants participants = new Participants(1L);
+
+            assertThatCode(() -> participants.add(2L))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("이미 존재하는 사용자를 추가하면 예외가 발생한다")
+        @Test
+        void memberIsAlreadyParticipant() {
+            final long memberId = 1L;
+            final Participants participants = new Participants(memberId);
+
+            assertThatThrownBy(() -> participants.add(memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("이미 참여된 사용자입니다.");
+        }
+    }
+
+    @DisplayName("인원수가 더 많은 지에 대한 테스트")
+    @Nested
+    public class validateCapacityIsOver {
+        
+        @DisplayName("참여자보다 인원 수가 더 많을 경우 예외가 발생하지 않는다")
+        @Test
+        void capacityIsOver() {
+            final Capacity capacity = new Capacity(5);
+            final Participants participants = new Participants(1L);
+
+            assertThatCode(() -> participants.validateCapacityIsOver(capacity))
+                .doesNotThrowAnyException();
+        }
+        
+        @DisplayName("참여자보다 인원 수가 더 적을 경우 예외가 발생한다")
+        @Test
+        void capacityIsLower() {
+            final Capacity capacity = new Capacity(2);
+            final Participants participants = new Participants(1L);
+            participants.add(2L);
+            participants.add(3L);
+
+            assertThatThrownBy(() -> participants.validateCapacityIsOver(capacity))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여자 수용인원이 다 찼습니다.");
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -86,6 +86,35 @@ class ParticipantsTest {
         }
     }
 
+    @DisplayName("탈퇴 테스트")
+    @Nested
+    public class withdraw {
+
+        @DisplayName("탈퇴한다")
+        @Test
+        void success() {
+            final Participants participants = new Participants(runningCrew);
+
+            participants.withdraw(HOST_ID);
+
+            final Participant participant = participants.getValue().stream()
+                .filter(value -> value.getMemberId().equals(HOST_ID))
+                .findFirst().get();
+            assertThat(participant.getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
+        }
+
+        @DisplayName("참여자가 아닐 경우 예외가 발생한다")
+        @Test
+        void memberIsNotParticipant() {
+            final long memberId = 2L;
+            final Participants participants = new Participants(runningCrew);
+
+            assertThatThrownBy(() -> participants.withdraw(memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여자가 아닙니다.");
+        }
+    }
+
     @DisplayName("인원수가 더 많은 지에 대한 테스트")
     @Nested
     public class validateCapacityIsOver {
@@ -173,6 +202,23 @@ class ParticipantsTest {
             assertThatThrownBy(() -> participants.validateMemberIsRequested(memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여자가 아닙니다.");
+        }
+    }
+
+    @DisplayName("참여중인 사용자 수 조회 테스트")
+    @Nested
+    public class getNumberOrParticipants {
+
+        @DisplayName("참여자 목록 중 '참여중' 인 사용자의 수를 조회한다")
+        @Test
+        void success() {
+            final Participants participants = new Participants(runningCrew);
+            participants.add(runningCrew, 2L);
+            participants.add(runningCrew, 3L);
+
+            final int numberOrParticipants = participants.getNumberOrParticipants();
+
+            assertThat(numberOrParticipants).isEqualTo(1);
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
@@ -34,4 +34,29 @@ class ProgressionTypeTest {
             );
         }
     }
+
+    @DisplayName("생성 또는 준비 또는 진행중에 대한 테스트")
+    @Nested
+    public class isCreatedOrReadyOrInProgress {
+
+        @DisplayName("생성 또는 준비 또는 진행중이면 true 를 반환한다")
+        @Test
+        void createdOrReadyOrInProgress() {
+            assertAll(
+                () -> assertThat(ProgressionType.CREATED.isCreatedOrReadyOrInProgress()).isTrue(),
+                () -> assertThat(ProgressionType.READY.isCreatedOrReadyOrInProgress()).isTrue(),
+                () -> assertThat(ProgressionType.IN_PROGRESS.isCreatedOrReadyOrInProgress()).isTrue()
+            );
+        }
+
+        @DisplayName("생성 또는 준비 또는 진행중이 아니면 false 를 반환한다")
+        @Test
+        void notCreatedAndReadyAndInProgress() {
+            assertAll(
+                () -> assertThat(ProgressionType.COMPLETED.isCreatedOrReadyOrInProgress()).isFalse(),
+                () -> assertThat(ProgressionType.CANCELLED.isCreatedOrReadyOrInProgress()).isFalse(),
+                () -> assertThat(ProgressionType.EXPIRED.isCreatedOrReadyOrInProgress()).isFalse()
+            );
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
@@ -1,0 +1,37 @@
+package com.dobugs.yologaapi.domain.runningcrew;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ProgressionType 도메인 테스트")
+class ProgressionTypeTest {
+
+    @DisplayName("시작 테스트")
+    @Nested
+    public class isReady {
+
+        @DisplayName("준비중이면 true 를 반환한다")
+        @Test
+        void ready() {
+            assertAll(
+                () -> assertThat(ProgressionType.CREATED.isReady()).isTrue(),
+                () -> assertThat(ProgressionType.READY.isReady()).isTrue()
+            );
+        }
+
+        @DisplayName("준비가 끝났으면 false 를 반환한다")
+        @Test
+        void notReady() {
+            assertAll(
+                () -> assertThat(ProgressionType.IN_PROGRESS.isReady()).isFalse(),
+                () -> assertThat(ProgressionType.COMPLETED.isReady()).isFalse(),
+                () -> assertThat(ProgressionType.CANCELLED.isReady()).isFalse(),
+                () -> assertThat(ProgressionType.EXPIRED.isReady()).isFalse()
+            );
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
@@ -10,27 +10,27 @@ import org.junit.jupiter.api.Test;
 @DisplayName("ProgressionType 도메인 테스트")
 class ProgressionTypeTest {
 
-    @DisplayName("시작 테스트")
+    @DisplayName("생성 또는 준비에 대한 테스트")
     @Nested
-    public class isReady {
+    public class isCreatedOrReady {
 
-        @DisplayName("준비중이면 true 를 반환한다")
+        @DisplayName("생성 또는 준비중이면 true 를 반환한다")
         @Test
-        void ready() {
+        void createdOrReady() {
             assertAll(
-                () -> assertThat(ProgressionType.CREATED.isReady()).isTrue(),
-                () -> assertThat(ProgressionType.READY.isReady()).isTrue()
+                () -> assertThat(ProgressionType.CREATED.isCreatedOrReady()).isTrue(),
+                () -> assertThat(ProgressionType.READY.isCreatedOrReady()).isTrue()
             );
         }
 
-        @DisplayName("준비가 끝났으면 false 를 반환한다")
+        @DisplayName("생성 또는 준비중이 아니면 false 를 반환한다")
         @Test
-        void notReady() {
+        void notCreatedAndReady() {
             assertAll(
-                () -> assertThat(ProgressionType.IN_PROGRESS.isReady()).isFalse(),
-                () -> assertThat(ProgressionType.COMPLETED.isReady()).isFalse(),
-                () -> assertThat(ProgressionType.CANCELLED.isReady()).isFalse(),
-                () -> assertThat(ProgressionType.EXPIRED.isReady()).isFalse()
+                () -> assertThat(ProgressionType.IN_PROGRESS.isCreatedOrReady()).isFalse(),
+                () -> assertThat(ProgressionType.COMPLETED.isCreatedOrReady()).isFalse(),
+                () -> assertThat(ProgressionType.CANCELLED.isCreatedOrReady()).isFalse(),
+                () -> assertThat(ProgressionType.EXPIRED.isCreatedOrReady()).isFalse()
             );
         }
     }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -472,4 +472,50 @@ class RunningCrewTest {
                 .hasMessageContaining("이미 완료되었습니다.");
         }
     }
+
+    @DisplayName("참여 요청 거절 테스트")
+    @Nested
+    public class reject {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("참여 요청을 거절한다")
+        @Test
+        void success() {
+            final long memberId = 1L;
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.participate(memberId);
+
+            runningCrew.reject(HOST_ID, memberId);
+
+            final Optional<Participant> participant = runningCrew.getParticipants()
+                .getValue()
+                .stream()
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.REJECTED);
+        }
+
+        @DisplayName("승인자가 호스트가 아닐 경우 예외가 발생한다")
+        @Test
+        void memberIsNotHost() {
+            final long memberId = 1L;
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+
+            assertThatThrownBy(() -> runningCrew.reject(memberId, memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("호스트가 아닙니다.");
+        }
+
+        @DisplayName("호스트일 경우 예외가 발생한다")
+        @Test
+        void memberIsHost() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+
+            assertThatThrownBy(() -> runningCrew.reject(HOST_ID, HOST_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("러닝크루의 호스트입니다.");
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -330,12 +330,12 @@ class RunningCrewTest {
             runningCrew.participate(memberId);
             runningCrew.cancel(memberId);
 
-            final List<Long> idsOfParticipants = runningCrew.getParticipants()
+            final Participant participant = runningCrew.getParticipants()
                 .getValue()
                 .stream()
-                .map(Participant::getMemberId)
-                .toList();
-            assertThat(idsOfParticipants).doesNotContain(memberId);
+                .filter(value -> value.getMemberId().equals(memberId))
+                .findFirst().get();
+            assertThat(participant.getStatus()).isEqualTo(ParticipantType.CANCELLED);
         }
 
         @DisplayName("호스트일 경우 예외가 발생한다")

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -323,7 +323,7 @@ class RunningCrewTest {
 
             assertThatThrownBy(() -> runningCrew.participate(memberId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("이미 시작되었습니다.");
+                .hasMessageContaining("이미 진행중이거나 완료되었습니다.");
         }
     }
 

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -61,11 +61,7 @@ class RunningCrewTest {
         @DisplayName("러닝크루를 수정한다")
         @Test
         void success() {
-            final RunningCrew runningCrew = new RunningCrew(
-                HOST_ID, COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
-                NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
-                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
-            );
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
 
             assertThatCode(() -> runningCrew.update(
                 HOST_ID,
@@ -79,12 +75,7 @@ class RunningCrewTest {
         @Test
         void memberIsNotHost() {
             final long memberId = -1L;
-
-            final RunningCrew runningCrew = new RunningCrew(
-                HOST_ID, COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
-                NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
-                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
-            );
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
 
             assertThatThrownBy(() -> runningCrew.update(
                 memberId,
@@ -100,19 +91,14 @@ class RunningCrewTest {
         void startShouldBeBeforeThanEnd() {
             final LocalDateTime start = LocalDateTime.now();
             final LocalDateTime end = start.minusDays(1);
-
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
 
-            assertThatThrownBy(
-                () -> runningCrew.update(
-                    HOST_ID,
-                    COORDINATES, COORDINATES,
-                    new Capacity(RUNNING_CREW_CAPACITY), start, end,
-                    new Deadline(AFTER_ONE_HOUR),
-                    RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
-                )
-            )
-                .isInstanceOf(IllegalArgumentException.class)
+            assertThatThrownBy(() -> runningCrew.update(
+                HOST_ID,
+                COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
+                start, end, new Deadline(AFTER_ONE_HOUR),
+                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+            )).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("시작 시간은 종료 시간보다 앞서있어야 합니다.");
         }
     }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -276,18 +276,6 @@ class RunningCrewTest {
                 .hasMessageContaining("러닝크루의 호스트입니다.");
         }
 
-        @DisplayName("기존에 참여되어 있으면 예외가 발생한다")
-        @Test
-        void memberIsParticipant() {
-            final long memberId = 1L;
-            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
-            runningCrew.participate(memberId);
-
-            assertThatThrownBy(() -> runningCrew.participate(memberId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("이미 참여중입니다.");
-        }
-
         @DisplayName("수용 인원이 다 찼을 경우 예외가 발생한다")
         @Test
         void capacityIsFull() {
@@ -371,6 +359,35 @@ class RunningCrewTest {
             assertThatThrownBy(() -> runningCrew.cancel(memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("참여자가 아닙니다.");
+        }
+    }
+
+    @DisplayName("탈퇴 테스트")
+    @Nested
+    public class withdraw {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("탈퇴한다")
+        @Test
+        void success() {
+            final long memberId = 1L;
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+
+            runningCrew.participate(memberId);
+            // todo: 참여 요청 승인 구현 후 테스트 작성..
+        }
+
+        @DisplayName("탈퇴 후 참여자가 호스트뿐이고 러닝크루 상태가 생성 또는 준비 상태이면 '생성' 상태로 변환된다")
+        @Test
+        void participantIsOnlyOne() {
+
+        }
+
+        @DisplayName("호스트일 경우 예외가 발생한다")
+        @Test
+        void memberIsHost() {
+
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -11,6 +11,7 @@ import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
 
@@ -166,7 +167,10 @@ class RunningCrewTest {
 
             runningCrew.start(HOST_ID);
 
-            assertThat(runningCrew.getImplementedStartDate()).isNotNull();
+            assertAll(
+                () -> assertThat(runningCrew.getImplementedStartDate()).isNotNull(),
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.IN_PROGRESS)
+            );
         }
 
         @DisplayName("호스트가 아닐 경우 예외가 발생한다")
@@ -207,7 +211,10 @@ class RunningCrewTest {
             runningCrew.start(HOST_ID);
             runningCrew.end(HOST_ID);
 
-            assertThat(runningCrew.getImplementedEndDate()).isNotNull();
+            assertAll(
+                () -> assertThat(runningCrew.getImplementedEndDate()).isNotNull(),
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.COMPLETED)
+            );
         }
 
         @DisplayName("호스트가 아닐 경우 예외가 발생한다")

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
@@ -11,7 +11,7 @@ import com.dobugs.yologaapi.domain.runningcrew.Capacity;
 import com.dobugs.yologaapi.domain.runningcrew.Coordinates;
 import com.dobugs.yologaapi.domain.runningcrew.Deadline;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
-import com.dobugs.yologaapi.domain.runningcrew.RunningCrewProgression;
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.service.dto.common.CoordinatesDto;
 import com.dobugs.yologaapi.service.dto.common.DateDto;
 import com.dobugs.yologaapi.service.dto.common.DatesDto;
@@ -88,7 +88,7 @@ public class RunningCrewFixture {
 
     public static RunningCrewSummaryResponse createRunningCrewSummaryResponse() {
         return new RunningCrewSummaryResponse(
-            1L, LOCATION_DTO, RunningCrewProgression.CREATED.name(), LocalDateTime.now()
+            1L, LOCATION_DTO, ProgressionType.CREATED.name(), LocalDateTime.now()
         );
     }
 
@@ -100,7 +100,7 @@ public class RunningCrewFixture {
 
     public static RunningCrewResponse createRunningCrewResponse(final Long runningCrewId) {
         return new RunningCrewResponse(
-            runningCrewId, RUNNING_CREW_TITLE, 1L, LOCATIONS_DTO, RunningCrewProgression.CREATED.name(),
+            runningCrewId, RUNNING_CREW_TITLE, 1L, LOCATIONS_DTO, ProgressionType.CREATED.name(),
             RUNNING_CREW_CAPACITY, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
         );
     }
@@ -113,7 +113,7 @@ public class RunningCrewFixture {
         final RunningCrew runningCrew = mock(RunningCrew.class);
         given(runningCrew.getDeparture()).willReturn(point);
         given(runningCrew.getArrival()).willReturn(point);
-        given(runningCrew.getStatus()).willReturn(RunningCrewProgression.CREATED);
+        given(runningCrew.getStatus()).willReturn(ProgressionType.CREATED);
         given(runningCrew.getCapacity()).willReturn(new Capacity(RUNNING_CREW_CAPACITY));
         given(runningCrew.getDeadline()).willReturn(new Deadline(AFTER_ONE_HOUR));
 

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
@@ -72,10 +72,26 @@ public class RunningCrewFixture {
         );
     }
 
-    public static RunningCrew createRunningCrewWith(final LocalDateTime start, final LocalDateTime end) {
+    public static RunningCrew createRunningCrewWithCapacity(final Long hostId, final int capacity) {
+        return createRunningCrew(
+            hostId, COORDINATES, COORDINATES, capacity,
+            NOW, AFTER_ONE_HOUR, AFTER_ONE_HOUR,
+            RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+        );
+    }
+
+    public static RunningCrew createRunningCrewWithScheduledDate(final LocalDateTime start, final LocalDateTime end) {
         return createRunningCrew(
             1L, COORDINATES, COORDINATES, RUNNING_CREW_CAPACITY,
             start, end, AFTER_ONE_HOUR,
+            RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+        );
+    }
+
+    public static RunningCrew createRunningCrewWithDeadline(final Long hostId, final LocalDateTime deadline) {
+        return createRunningCrew(
+            hostId, COORDINATES, COORDINATES, RUNNING_CREW_CAPACITY,
+            NOW, AFTER_ONE_HOUR, deadline,
             RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
         );
     }

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -32,7 +32,7 @@ class RunningCrewRepositoryTest {
     @Autowired
     private TestEntityManager entityManager;
 
-    @DisplayName("러닝크루 아이디를 이용하여 러닝크루 정보를 조회하는 테스트")
+    @DisplayName("러닝크루 아이디를 이용하여 러닝크루 정보 조회")
     @Nested
     public class findByIdAndArchivedIsTrue {
 
@@ -75,7 +75,7 @@ class RunningCrewRepositoryTest {
         }
     }
 
-    @DisplayName("내 주변에 있는 러닝크루 목록을 조회한다")
+    @DisplayName("내 주변 러닝크루 목록 조회")
     @Nested
     public class findNearby {
 

--- a/src/test/java/com/dobugs/yologaapi/repository/participantRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/participantRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.dobugs.yologaapi.repository;
+
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrew;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
+import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
+import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+@DisplayName("Participant 레포지토리 테스트")
+class ParticipantRepositoryTest {
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private RunningCrewRepository runningCrewRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @DisplayName("러닝크루의 참여자 목록 정보 조회")
+    @Nested
+    public class findParticipants {
+
+        private static final Long HOST_ID = 1L;
+        private static final List<Long> MEMBERS = List.of(2L, 3L);
+
+        @DisplayName("러닝크루의 참여자 목록 정보를 조회한다")
+        @Test
+        void success() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            for (final Long memberId : MEMBERS) {
+                runningCrew.participate(memberId);
+                runningCrew.accept(HOST_ID, memberId);
+            }
+            final RunningCrew savedRunningCrew = runningCrewRepository.save(runningCrew);
+
+            final List<ParticipantDto> response = participantRepository.findParticipants(savedRunningCrew.getId(), ParticipantType.PARTICIPATING.getSavedName());
+
+            assertThat(response).hasSize(MEMBERS.size() + 1);
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -107,4 +107,65 @@ class ParticipationServiceTest {
             assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.CANCELLED);
         }
     }
+
+    @DisplayName("탈퇴 테스트")
+    @Nested
+    public class withdraw {
+
+        @DisplayName("러닝크루에 탈퇴한다")
+        @Test
+        void success() {
+            final long runningCrewId = 0L;
+
+            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+
+            participationService.participate(memberServiceToken, runningCrewId);
+            participationService.accept(hostServiceToken, runningCrewId, MEMBER_ID);
+            participationService.withdraw(memberServiceToken, runningCrewId);
+
+            final Optional<Participant> participant = runningCrew.getParticipants()
+                .getValue()
+                .stream()
+                .filter(value -> value.getMemberId().equals(MEMBER_ID))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.WITHDRAWN);
+        }
+    }
+
+    @DisplayName("참여 요청 승인 테스트")
+    @Nested
+    public class accept {
+
+        @DisplayName("러닝크루 참여 요청을 승인한다")
+        @Test
+        void success() {
+            final long runningCrewId = 0L;
+
+            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+
+            participationService.participate(memberServiceToken, runningCrewId);
+            participationService.accept(hostServiceToken, runningCrewId, MEMBER_ID);
+
+            final Optional<Participant> participant = runningCrew.getParticipants()
+                .getValue()
+                .stream()
+                .filter(value -> value.getMemberId().equals(MEMBER_ID))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -70,12 +70,13 @@ class ParticipationServiceTest {
 
             participationService.participate(serviceToken, runningCrewId);
 
-            final Participant participant = runningCrew.getParticipants()
+            final Optional<Participant> participant = runningCrew.getParticipants()
                 .getValue()
                 .stream()
                 .filter(value -> value.getMemberId().equals(MEMBER_ID))
-                .findFirst().get();
-            assertThat(participant.getStatus()).isEqualTo(ParticipantType.REQUESTED);
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.REQUESTED);
         }
     }
 

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -4,7 +4,6 @@ import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -103,7 +102,8 @@ class ParticipationServiceTest {
                 .stream()
                 .filter(value -> value.getMemberId().equals(MEMBER_ID))
                 .findFirst();
-            assertThat(participant).isEmpty();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.CANCELLED);
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -168,4 +168,34 @@ class ParticipationServiceTest {
             assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
         }
     }
+
+    @DisplayName("참여 요청 거절 테스트")
+    @Nested
+    public class reject {
+
+        @DisplayName("러닝크루 참여 요청을 거절한다")
+        @Test
+        void success() {
+            final long runningCrewId = 0L;
+
+            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+
+            participationService.participate(memberServiceToken, runningCrewId);
+            participationService.reject(hostServiceToken, runningCrewId, MEMBER_ID);
+
+            final Optional<Participant> participant = runningCrew.getParticipants()
+                .getValue()
+                .stream()
+                .filter(value -> value.getMemberId().equals(MEMBER_ID))
+                .findFirst();
+            assertThat(participant).isPresent();
+            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.REJECTED);
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
@@ -9,6 +9,7 @@ import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -25,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.repository.RunningCrewRepository;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
@@ -219,7 +221,10 @@ class RunningCrewServiceTest {
 
             runningCrewService.start(serviceToken, runningCrewId);
 
-            assertThat(savedRunningCrew.getImplementedStartDate()).isNotNull();
+            assertAll(
+                () -> assertThat(savedRunningCrew.getImplementedStartDate()).isNotNull(),
+                () -> assertThat(savedRunningCrew.getStatus()).isEqualTo(ProgressionType.IN_PROGRESS)
+            );
         }
 
         @DisplayName("존재하지 않는 아이디로 러닝크루를 시작할 수 없다")
@@ -252,7 +257,10 @@ class RunningCrewServiceTest {
 
             runningCrewService.end(serviceToken, runningCrewId);
 
-            assertThat(savedRunningCrew.getImplementedEndDate()).isNotNull();
+            assertAll(
+                () -> assertThat(savedRunningCrew.getImplementedEndDate()).isNotNull(),
+                () -> assertThat(savedRunningCrew.getStatus()).isEqualTo(ProgressionType.COMPLETED)
+            );
         }
 
         @DisplayName("존재하지 않는 아이디로 러닝크루를 종료할 수 없다")


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-154
- https://dobugs.atlassian.net/browse/YOL-155
- https://dobugs.atlassian.net/browse/YOL-156
- https://dobugs.atlassian.net/browse/YOL-157
- https://dobugs.atlassian.net/browse/YOL-163
- https://dobugs.atlassian.net/browse/YOL-164

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 아래 기능들을 구현하였습니다.
  - 러닝크루 참여자 목록 조회
  - 러닝크루 참여 요청
  - 러닝크루 참여 요청 취소
  - 러닝크루 탈퇴
  - 러닝크루 참여 요청 승인
  - 러닝크루 참여 요청 거절
- 초기에는 RunningCrew 와 Participant 의 연관관계를 일대다 단방향으로 두었습니다. 하지만 실제 컬럼을 가지고 있는 Participant 가 아닌 RunningCrew 에서 FK 를 관리하니, 해당 값이 자동으로 저장되지 않는 문제가 있었습니다. 따라서 `다대일 양방향` 으로 변경하였습니다.
- 두벅스 '사용자' 정보를 별도의 서버로 분리하여 욜로가 서버에서는 사용자 엔티티가 존재하지 않습니다. 하지만 '러닝크루 참여자 목록 조회' 에서 사용자의 이름 정보가 필요합니다. 이러한 부분을 해결하기 위해 `JPA 의 DTO projection + nativeQuery` 를 이용하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
