### PR TITLE
feat: 현재 진행중인 내 러닝크루 목록 조회, 내가 주최한/참여한 러닝크루 목록 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -23,6 +23,12 @@ include::{snippets}/running-crew/findInProgress/http-request.adoc[]
 Response
 include::{snippets}/running-crew/findInProgress/http-response.adoc[]
 
+== 내가 주최한 러닝크루 목록 조회
+Request
+include::{snippets}/running-crew/findHosted/http-request.adoc[]
+Response
+include::{snippets}/running-crew/findHosted/http-response.adoc[]
+
 == 러닝크루 상세정보 조회
 Request
 include::{snippets}/running-crew/findById/http-request.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -29,6 +29,12 @@ include::{snippets}/running-crew/findHosted/http-request.adoc[]
 Response
 include::{snippets}/running-crew/findHosted/http-response.adoc[]
 
+== 내가 참여한 러닝크루 목록 조회
+Request
+include::{snippets}/running-crew/findParticipated/http-request.adoc[]
+Response
+include::{snippets}/running-crew/findParticipated/http-response.adoc[]
+
 == 러닝크루 상세정보 조회
 Request
 include::{snippets}/running-crew/findById/http-request.adoc[]

--- a/src/docs/asciidoc/running-crew.adoc
+++ b/src/docs/asciidoc/running-crew.adoc
@@ -17,6 +17,12 @@ include::{snippets}/running-crew/findNearby/http-request.adoc[]
 Response
 include::{snippets}/running-crew/findNearby/http-response.adoc[]
 
+== 현재 진행중인 내 러닝크루 목록 조회
+Request
+include::{snippets}/running-crew/findInProgress/http-request.adoc[]
+Response
+include::{snippets}/running-crew/findInProgress/http-response.adoc[]
+
 == 러닝크루 상세정보 조회
 Request
 include::{snippets}/running-crew/findById/http-request.adoc[]

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaapi.service.ParticipationService;
-import com.dobugs.yologaapi.service.dto.request.ParticipantsRequest;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class ParticipationController {
     @GetMapping("/participants")
     public ResponseEntity<ParticipantsResponse> findParticipants(
         @PathVariable final Long runningCrewId,
-        @ModelAttribute final ParticipantsRequest request
+        @ModelAttribute final PagingRequest request
     ) {
         final ParticipantsResponse response = participationService.findParticipants(runningCrewId, request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
@@ -66,6 +66,15 @@ public class RunningCrewController {
         return ResponseEntity.ok().body(response);
     }
 
+    @GetMapping("/participated")
+    public ResponseEntity<RunningCrewsResponse> findParticipated(
+        @RequestHeader("Authorization") final String accessToken,
+        @ModelAttribute final RunningCrewStatusRequest request
+    ) {
+        final RunningCrewsResponse response = runningCrewService.findParticipated(accessToken, request);
+        return ResponseEntity.ok().body(response);
+    }
+
     @GetMapping("/{runningCrewId}")
     public ResponseEntity<RunningCrewResponse> findById(@PathVariable final Long runningCrewId) {
         final RunningCrewResponse response = runningCrewService.findById(runningCrewId);

--- a/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
@@ -18,6 +18,7 @@ import com.dobugs.yologaapi.service.RunningCrewService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewFindNearbyRequest;
+import com.dobugs.yologaapi.service.dto.request.RunningCrewStatusRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
@@ -53,6 +54,15 @@ public class RunningCrewController {
         @ModelAttribute final PagingRequest request
     ) {
         final RunningCrewsResponse response = runningCrewService.findInProgress(accessToken, request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/hosted")
+    public ResponseEntity<RunningCrewsResponse> findHosted(
+        @RequestHeader("Authorization") final String accessToken,
+        @ModelAttribute final RunningCrewStatusRequest request
+    ) {
+        final RunningCrewsResponse response = runningCrewService.findHosted(accessToken, request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaapi.service.RunningCrewService;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewFindNearbyRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
+import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +44,15 @@ public class RunningCrewController {
     @GetMapping
     public ResponseEntity<RunningCrewFindNearbyResponse> findNearby(@ModelAttribute final RunningCrewFindNearbyRequest request) {
         final RunningCrewFindNearbyResponse response = runningCrewService.findNearby(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/in-progress")
+    public ResponseEntity<RunningCrewsResponse> findInProgress(
+        @RequestHeader("Authorization") final String accessToken,
+        @ModelAttribute final PagingRequest request
+    ) {
+        final RunningCrewsResponse response = runningCrewService.findInProgress(accessToken, request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -7,18 +7,20 @@ import lombok.Getter;
 @Getter
 public enum ProgressionType {
 
-    CREATED("생성"),
-    READY("준비"),
-    IN_PROGRESS("진행중"),
-    COMPLETED("완료"),
-    CANCELLED("취소"),
-    EXPIRED("만료"),
+    CREATED("생성", "CREATED"),
+    READY("준비", "READY"),
+    IN_PROGRESS("진행중", "IN_PROGRESS"),
+    COMPLETED("완료", "COMPLETED"),
+    CANCELLED("취소", "CANCELLED"),
+    EXPIRED("만료", "EXPIRED"),
     ;
 
-    private final String name;
+    private final String description;
+    private final String savedName;
 
-    ProgressionType(final String name) {
-        this.name = name;
+    ProgressionType(final String description, final String savedName) {
+        this.description = description;
+        this.savedName = savedName;
     }
 
     public boolean isCreatedOrReady() {

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -23,6 +23,14 @@ public enum ProgressionType {
         this.savedName = savedName;
     }
 
+    public static ProgressionType from(final String value) {
+        try {
+            return ProgressionType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("잘못된 상태값입니다. [%s]", value));
+        }
+    }
+
     public boolean isCreatedOrReady() {
         return List.of(CREATED, READY).contains(this);
     }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionType.java
@@ -31,6 +31,10 @@ public enum ProgressionType {
         }
     }
 
+    public boolean isCreated() {
+        return this.equals(CREATED);
+    }
+
     public boolean isCreatedOrReady() {
         return List.of(CREATED, READY).contains(this);
     }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -151,6 +151,7 @@ public class RunningCrew extends BaseEntity {
         deadline.validateDeadlineIsNotOver();
         validateRunningCrewStatusIsCreatedOrReadyOrInProgress();
         participants.accept(memberId);
+        ready();
     }
 
     public void reject(final Long hostId, final Long memberId) {
@@ -163,6 +164,12 @@ public class RunningCrew extends BaseEntity {
         final int number = participants.getNumberOrParticipants();
         if (number == 1 && status.isCreatedOrReady()) {
             status = ProgressionType.CREATED;
+        }
+    }
+
+    private void ready() {
+        if (status.isCreated()) {
+            status = ProgressionType.READY;
         }
     }
 
@@ -216,7 +223,7 @@ public class RunningCrew extends BaseEntity {
         }
     }
 
-    private Point  wktToPoint(final Coordinates coordinates) {
+    private Point wktToPoint(final Coordinates coordinates) {
         final String wellKnownText = String.format("POINT(%f %f)", coordinates.longitude(), coordinates.latitude());
         try {
             return (Point) new WKTReader().read(wellKnownText);

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -206,13 +206,13 @@ public class RunningCrew extends BaseEntity {
 
     private void validateRunningCrewStatusIsCreatedOrReady() {
         if (!status.isCreatedOrReady()) {
-            throw new IllegalArgumentException(String.format("이미 진행중이거나 완료되었습니다. [%s]", status.getName()));
+            throw new IllegalArgumentException(String.format("이미 진행중이거나 완료되었습니다. [%s]", status.getDescription()));
         }
     }
 
     private void validateRunningCrewStatusIsCreatedOrReadyOrInProgress() {
         if (!status.isCreatedOrReadyOrInProgress()) {
-            throw new IllegalArgumentException(String.format("이미 완료되었습니다. [%s]", status.getName()));
+            throw new IllegalArgumentException(String.format("이미 완료되었습니다. [%s]", status.getDescription()));
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 
 public interface RunningCrewRepository extends JpaRepository<RunningCrew, Long> {
@@ -48,4 +49,8 @@ public interface RunningCrewRepository extends JpaRepository<RunningCrew, Long> 
         nativeQuery = true
     )
     Page<RunningCrew> findInProgress(final Long memberId, final String runningCrewStatus, final String participantStatus, final Pageable pageable);
+
+    Page<RunningCrew> findByMemberIdAndArchivedIsTrue(final Long memberId, final Pageable pageable);
+
+    Page<RunningCrew> findByMemberIdAndStatusAndArchivedIsTrue(final Long memberId, final ProgressionType progressionType, final Pageable pageable);
 }

--- a/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
@@ -53,4 +53,50 @@ public interface RunningCrewRepository extends JpaRepository<RunningCrew, Long> 
     Page<RunningCrew> findByMemberIdAndArchivedIsTrue(final Long memberId, final Pageable pageable);
 
     Page<RunningCrew> findByMemberIdAndStatusAndArchivedIsTrue(final Long memberId, final ProgressionType progressionType, final Pageable pageable);
+
+    @Query(
+        value = "SELECT rc.*\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE\n"
+            + "p.member_id = ?1 AND p.status = ?2 AND p.archived = true\n"
+            + "AND\n"
+            + "rc.archived = true\n"
+            + ";",
+        countQuery = "SELECT count(rc.id)\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE\n"
+            + "p.member_id = ?1 AND p.status = ?2 AND p.archived = true\n"
+            + "AND\n"
+            + "rc.archived = true\n"
+            + ";",
+        nativeQuery = true
+    )
+    Page<RunningCrew> findParticipated(final Long memberId, final String participantStatus, final Pageable pageable);
+
+    @Query(
+        value = "SELECT rc.*\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE\n"
+            + "p.member_id = ?1 AND p.status = ?3 AND p.archived = true\n"
+            + "AND\n"
+            + "rc.status = ?2 AND rc.archived = true\n"
+            + ";",
+        countQuery = "SELECT count(rc.id)\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE\n"
+            + "p.member_id = ?1 AND p.status = ?3 AND p.archived = true\n"
+            + "AND\n"
+            + "rc.status = ?2 AND rc.archived = true\n"
+            + ";",
+        nativeQuery = true
+    )
+    Page<RunningCrew> findParticipatedByStatus(final Long memberId, final String runningCrewStatus, final String participantStatus, final Pageable pageable);
 }

--- a/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
@@ -25,4 +25,27 @@ public interface RunningCrewRepository extends JpaRepository<RunningCrew, Long> 
         nativeQuery = true
     )
     Page<RunningCrew> findNearby(final Double latitude, final Double longitude, final int radius, final Pageable pageable);
+
+    @Query(
+        value = "SELECT rc.*\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE \n"
+            + "rc.status = ?2 AND rc.archived = true\n"
+            + "AND\n"
+            + "p.member_id = ?1 AND p.status = ?3 AND p.archived = true\n"
+            + ";",
+        countQuery = "SELECT count(rc.id)\n"
+            + "FROM running_crew AS rc\n"
+            + "JOIN participant AS p\n"
+            + "ON rc.id = p.running_crew_id\n"
+            + "WHERE \n"
+            + "rc.status = ?2 AND rc.archived = true\n"
+            + "AND\n"
+            + "p.member_id = ?1 AND p.status = ?3 AND p.archived = true\n"
+            + ";",
+        nativeQuery = true
+    )
+    Page<RunningCrew> findInProgress(final Long memberId, final String runningCrewStatus, final String participantStatus, final Pageable pageable);
 }

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -11,7 +11,7 @@ import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.repository.ParticipantRepository;
 import com.dobugs.yologaapi.repository.RunningCrewRepository;
 import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
-import com.dobugs.yologaapi.service.dto.request.ParticipantsRequest;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.dobugs.yologaapi.support.TokenGenerator;
 import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
@@ -28,7 +28,7 @@ public class ParticipationService {
     private final TokenGenerator tokenGenerator;
 
     @Transactional(readOnly = true)
-    public ParticipantsResponse findParticipants(final Long runningCrewId, final ParticipantsRequest request) {
+    public ParticipantsResponse findParticipants(final Long runningCrewId, final PagingRequest request) {
         final Pageable pageable = PageRequest.of(request.page(), request.size());
         final Page<ParticipantDto> response = participantRepository.findParticipants(runningCrewId, ParticipantType.PARTICIPATING.getSavedName(), pageable);
         return ParticipantsResponse.from(response);

--- a/src/main/java/com/dobugs/yologaapi/service/RunningCrewService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/RunningCrewService.java
@@ -9,16 +9,20 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dobugs.yologaapi.domain.runningcrew.Capacity;
 import com.dobugs.yologaapi.domain.runningcrew.Coordinates;
 import com.dobugs.yologaapi.domain.runningcrew.Deadline;
+import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.repository.RunningCrewRepository;
 import com.dobugs.yologaapi.service.dto.common.CoordinatesDto;
 import com.dobugs.yologaapi.service.dto.common.DateDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewFindNearbyRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
+import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
 import com.dobugs.yologaapi.support.TokenGenerator;
 import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
 
@@ -49,6 +53,18 @@ public class RunningCrewService {
             request.latitude(), request.longitude(), request.radius(), pageable
         );
         return RunningCrewFindNearbyResponse.from(runningCrews);
+    }
+
+    @Transactional(readOnly = true)
+    public RunningCrewsResponse findInProgress(final String serviceToken, final PagingRequest request) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final String runningCrewStatus = ProgressionType.IN_PROGRESS.getSavedName();
+        final String participantStatus = ParticipantType.PARTICIPATING.getSavedName();
+        final Pageable pageable = PageRequest.of(request.page(), request.size());
+        final Page<RunningCrew> runningCrews = runningCrewRepository.findInProgress(memberId, runningCrewStatus, participantStatus, pageable);
+        return RunningCrewsResponse.from(runningCrews);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dobugs/yologaapi/service/dto/request/PagingRequest.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/request/PagingRequest.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaapi.service.dto.request;
+
+public record PagingRequest(int page, int size) {
+}

--- a/src/main/java/com/dobugs/yologaapi/service/dto/request/ParticipantsRequest.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/request/ParticipantsRequest.java
@@ -1,4 +1,0 @@
-package com.dobugs.yologaapi.service.dto.request;
-
-public record ParticipantsRequest(int page, int size) {
-}

--- a/src/main/java/com/dobugs/yologaapi/service/dto/request/RunningCrewStatusRequest.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/request/RunningCrewStatusRequest.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaapi.service.dto.request;
+
+public record RunningCrewStatusRequest(String status, int page, int size) {
+}

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
@@ -6,7 +6,7 @@ import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.service.dto.common.DatesDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
 
-public record RunningCrewResponse(Long id, String title, Long host, LocationsDto locationsDto, String status,
+public record RunningCrewResponse(Long id, String title, Long host, LocationsDto location, String status,
                                   int capacity, DatesDto date, LocalDateTime deadline, String description) {
 
     public static RunningCrewResponse from(final RunningCrew runningCrew) {

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewsResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewsResponse.java
@@ -1,0 +1,21 @@
+package com.dobugs.yologaapi.service.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
+
+public record RunningCrewsResponse(long totalElements, int page, int size, List<RunningCrewResponse> content) {
+
+    public static RunningCrewsResponse from(final Page<RunningCrew> runningCrews) {
+        return new RunningCrewsResponse(
+            runningCrews.getTotalElements(),
+            runningCrews.getNumber(),
+            runningCrews.getSize(),
+            runningCrews.getContent().stream()
+                .map(RunningCrewResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -38,9 +38,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.service.RunningCrewService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
+import com.dobugs.yologaapi.service.dto.request.RunningCrewStatusRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
@@ -135,6 +137,34 @@ class RunningCrewControllerTest {
             .andExpect(status().isOk())
             .andDo(document(
                 "running-crew/findInProgress",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("내가 주최한 러닝크루 목록을 조회한다")
+    @Test
+    void findHosted() throws Exception {
+        final String accessToken = "accessToken";
+        final String status = ProgressionType.CREATED.getSavedName();
+        final int page = 0;
+        final int size = 10;
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("status", status);
+        params.add("page", String.valueOf(page));
+        params.add("size", String.valueOf(size));
+
+        final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, page, size);
+        final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
+        given(runningCrewService.findHosted(accessToken, request)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/hosted")
+                .header("Authorization", accessToken)
+                .params(params))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "running-crew/findHosted",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -171,6 +171,34 @@ class RunningCrewControllerTest {
         ;
     }
 
+    @DisplayName("내가 참여한 러닝크루 목록을 조회한다")
+    @Test
+    void findParticipated() throws Exception {
+        final String accessToken = "accessToken";
+        final String status = ProgressionType.CREATED.getSavedName();
+        final int page = 0;
+        final int size = 10;
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("status", status);
+        params.add("page", String.valueOf(page));
+        params.add("size", String.valueOf(size));
+
+        final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, page, size);
+        final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
+        given(runningCrewService.findParticipated(accessToken, request)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/participated")
+                .header("Authorization", accessToken)
+                .params(params))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "running-crew/findParticipated",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
     @DisplayName("러닝크루의 상세정보를 조회한다")
     @Test
     void findById() throws Exception {

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -39,10 +39,12 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.dobugs.yologaapi.service.RunningCrewService;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
+import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @AutoConfigureMockMvc
@@ -107,6 +109,32 @@ class RunningCrewControllerTest {
             .andExpect(status().isOk())
             .andDo(document(
                 "running-crew/findNearby",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("현재 진행중인 내 러닝크루 목록을 조회한다")
+    @Test
+    void findInProgress() throws Exception {
+        final String accessToken = "accessToken";
+        final int page = 0;
+        final int size = 10;
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", String.valueOf(page));
+        params.add("size", String.valueOf(size));
+
+        final PagingRequest request = new PagingRequest(page, size);
+        final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
+        given(runningCrewService.findInProgress(accessToken, request)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/in-progress")
+                .header("Authorization", accessToken)
+                .params(params))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "running-crew/findInProgress",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
@@ -36,6 +36,29 @@ class ProgressionTypeTest {
         }
     }
 
+    @DisplayName("생성에 대한 테스트")
+    @Nested
+    public class isCreated {
+
+        @DisplayName("생성 상태이면 true 를 반환한다")
+        @Test
+        void created() {
+            assertThat(ProgressionType.CREATED.isCreated()).isTrue();
+        }
+
+        @DisplayName("생성 상태가 아니면 false 를 반환한다")
+        @Test
+        void notCreated() {
+            assertAll(
+                () -> assertThat(ProgressionType.READY.isCreated()).isFalse(),
+                () -> assertThat(ProgressionType.IN_PROGRESS.isCreated()).isFalse(),
+                () -> assertThat(ProgressionType.COMPLETED.isCreated()).isFalse(),
+                () -> assertThat(ProgressionType.CANCELLED.isCreated()).isFalse(),
+                () -> assertThat(ProgressionType.EXPIRED.isCreated()).isFalse()
+            );
+        }
+    }
+
     @DisplayName("생성 또는 준비에 대한 테스트")
     @Nested
     public class isCreatedOrReady {

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ProgressionTypeTest.java
@@ -1,6 +1,7 @@
 package com.dobugs.yologaapi.domain.runningcrew;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +10,31 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("ProgressionType 도메인 테스트")
 class ProgressionTypeTest {
+
+    @DisplayName("Enum 이름으로 ProgressionType 객체 조회 테스트")
+    @Nested
+    public class from {
+
+        @DisplayName("Enum 이 존재할 경우 올바른 객체를 반환한다")
+        @Test
+        void success() {
+            final String name = "CREATED";
+
+            final ProgressionType progressionType = ProgressionType.from(name);
+
+            assertThat(progressionType).isEqualTo(ProgressionType.CREATED);
+        }
+
+        @DisplayName("Enum 이 존재하지 않을 경우 예외가 발생한다")
+        @Test
+        void notExist() {
+            final String invalidProgressionType = "invalidProgressionType";
+
+            assertThatThrownBy(() -> ProgressionType.from(invalidProgressionType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("잘못된 상태값입니다.");
+        }
+    }
 
     @DisplayName("생성 또는 준비에 대한 테스트")
     @Nested

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -420,7 +420,10 @@ class RunningCrewTest {
                 .filter(value -> value.getMemberId().equals(memberId))
                 .findFirst();
             assertThat(participant).isPresent();
-            assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING);
+            assertAll(
+                () -> assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.READY)
+            );
         }
 
         @DisplayName("승인자가 호스트가 아닐 경우 예외가 발생한다")

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,9 +29,6 @@ class RunningCrewRepositoryTest {
 
     @Autowired
     private RunningCrewRepository runningCrewRepository;
-
-    @Autowired
-    private TestEntityManager entityManager;
 
     @DisplayName("러닝크루 아이디를 이용하여 러닝크루 정보 조회")
     @Nested
@@ -55,9 +51,8 @@ class RunningCrewRepositoryTest {
         @Test
         void archivedIsFalse() {
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.delete(HOST_ID);
             final RunningCrew savedRunningCrew = runningCrewRepository.save(runningCrew);
-            savedRunningCrew.delete(HOST_ID);
-            entityManager.flush();
 
             assertAll(
                 () -> assertThat(runningCrewRepository.findById(savedRunningCrew.getId())).isPresent(),
@@ -68,11 +63,11 @@ class RunningCrewRepositoryTest {
         @DisplayName("RunningCrew 가 존재하지 않을 경우 RunningCrew 를 조회하지 못한다")
         @Test
         void notExist() {
-            final long runningCrewId = 0L;
+            final long notExistRunningCrewId = 0L;
 
             assertAll(
-                () -> assertThat(runningCrewRepository.findById(runningCrewId)).isEmpty(),
-                () -> assertThat(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).isEmpty()
+                () -> assertThat(runningCrewRepository.findById(notExistRunningCrewId)).isEmpty(),
+                () -> assertThat(runningCrewRepository.findByIdAndArchivedIsTrue(notExistRunningCrewId)).isEmpty()
             );
         }
     }
@@ -118,6 +113,100 @@ class RunningCrewRepositoryTest {
             );
 
             assertThat(runningCrews).contains(savedRunningCrew);
+        }
+    }
+
+    @DisplayName("주최자 아이디를 이용하여 러닝크루 정보 조회")
+    @Nested
+    public class findByMemberIdAndArchivedIsTrue {
+
+        private static final Long HOST_ID = 0L;
+        private static final Pageable pageable = PageRequest.of(0, 5);
+
+        @DisplayName("archived 가 true 일 경우 RunningCrew 를 조회한다")
+        @Test
+        void archivedIsTrue() {
+            runningCrewRepository.save(createRunningCrew(HOST_ID));
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndArchivedIsTrue(HOST_ID, pageable);
+
+            assertThat(runningCrews.getContent()).isNotEmpty();
+        }
+
+        @DisplayName("archived 가 false 일 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void archivedIsFalse() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.delete(HOST_ID);
+            runningCrewRepository.save(runningCrew);
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndArchivedIsTrue(HOST_ID, pageable);
+
+            assertThat(runningCrews.getContent()).isEmpty();
+        }
+
+        @DisplayName("주최자 정보가 존재하지 않을 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void notExist() {
+            final long notExistHostId = -1L;
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndArchivedIsTrue(notExistHostId, pageable);
+
+            assertThat(runningCrews.getContent()).isEmpty();
+        }
+    }
+
+    @DisplayName("주최자 아이디와 러닝크루 상태값을 이용하여 러닝크루 정보 조회")
+    @Nested
+    public class findByMemberIdAndStatusAndArchivedIsTrue {
+
+        private static final Long HOST_ID = 0L;
+        private static final Pageable pageable = PageRequest.of(0, 5);
+
+        @DisplayName("archived 가 true 일 경우 RunningCrew 를 조회한다")
+        @Test
+        void archivedIsTrue() {
+            runningCrewRepository.save(createRunningCrew(HOST_ID));
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndStatusAndArchivedIsTrue(HOST_ID, ProgressionType.CREATED, pageable);
+
+            assertThat(runningCrews.getContent()).isNotEmpty();
+        }
+
+        @DisplayName("archived 가 false 일 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void archivedIsFalse() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.delete(HOST_ID);
+            runningCrewRepository.save(runningCrew);
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndStatusAndArchivedIsTrue(HOST_ID, ProgressionType.CREATED, pageable);
+
+            assertThat(runningCrews.getContent()).isEmpty();
+        }
+
+        @DisplayName("주최자에 해당하는 정보가 않을 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void notExistHost() {
+            final long notExistHostId = -1L;
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndStatusAndArchivedIsTrue(notExistHostId, ProgressionType.CREATED, pageable);
+
+            assertThat(runningCrews.getContent()).isEmpty();
+        }
+
+        @DisplayName("상태값에 해당하는 정보가 없을 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void notExistStatus() {
+            final ProgressionType notExistProgressionType = ProgressionType.EXPIRED;
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.delete(HOST_ID);
+            runningCrewRepository.save(runningCrew);
+
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findByMemberIdAndStatusAndArchivedIsTrue(HOST_ID, notExistProgressionType, pageable);
+
+            assertThat(runningCrews.getContent()).isEmpty();
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
+import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -94,6 +96,28 @@ class RunningCrewRepositoryTest {
             final Page<RunningCrew> runningCrews = runningCrewRepository.findNearby(LATITUDE, LONGITUDE, 100, pageable);
 
             assertThat(runningCrews).hasSizeGreaterThanOrEqualTo(count);
+        }
+    }
+
+    @DisplayName("현재 진행중인 내 러닝크루 목록 조회")
+    @Nested
+    public class findInProgress {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("현재 진행중인 내 러닝크루 목록을 조회한다")
+        @Test
+        void success() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.start(HOST_ID);
+            final RunningCrew savedRunningCrew = runningCrewRepository.save(runningCrew);
+
+            final Pageable pageable = PageRequest.of(0, 5);
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findInProgress(
+                HOST_ID, ProgressionType.IN_PROGRESS.getSavedName(), ParticipantType.PARTICIPATING.getSavedName(), pageable
+            );
+
+            assertThat(runningCrews).contains(savedRunningCrew);
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -209,4 +209,52 @@ class RunningCrewRepositoryTest {
             assertThat(runningCrews.getContent()).isEmpty();
         }
     }
+
+    @DisplayName("내가 참여한 러닝크루 목록 조회")
+    @Nested
+    public class findParticipated {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("내가 참여한 러닝크루 목록을 조회한다")
+        @Test
+        void success() {
+            final long memberId = -1L;
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.participate(memberId);
+            runningCrew.accept(HOST_ID, memberId);
+            runningCrewRepository.save(runningCrew);
+
+            final Pageable pageable = PageRequest.of(0, 5);
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findParticipated(memberId, ParticipantType.PARTICIPATING.getSavedName(), pageable);
+
+            assertThat(runningCrews.getContent()).isNotEmpty();
+        }
+    }
+
+    @DisplayName("상태값을 이용하여 내가 참여한 러닝크루 목록 조회")
+    @Nested
+    public class findParticipatedByStatus {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("상태값을 이용하여 내가 참여한 러닝크루 목록을 조회한다")
+        @Test
+        void success() {
+            final long memberId = -1L;
+
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.participate(memberId);
+            runningCrew.accept(HOST_ID, memberId);
+            runningCrewRepository.save(runningCrew);
+
+            final Pageable pageable = PageRequest.of(0, 5);
+            final Page<RunningCrew> runningCrews = runningCrewRepository.findParticipatedByStatus(
+                memberId, ProgressionType.CREATED.getSavedName(), ParticipantType.PARTICIPATING.getSavedName(), pageable
+            );
+
+            assertThat(runningCrews.getContent()).isNotEmpty();
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -251,7 +251,7 @@ class RunningCrewRepositoryTest {
 
             final Pageable pageable = PageRequest.of(0, 5);
             final Page<RunningCrew> runningCrews = runningCrewRepository.findParticipatedByStatus(
-                memberId, ProgressionType.CREATED.getSavedName(), ParticipantType.PARTICIPATING.getSavedName(), pageable
+                memberId, ProgressionType.READY.getSavedName(), ParticipantType.PARTICIPATING.getSavedName(), pageable
             );
 
             assertThat(runningCrews.getContent()).isNotEmpty();

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -25,7 +25,7 @@ import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.repository.ParticipantRepository;
 import com.dobugs.yologaapi.repository.RunningCrewRepository;
 import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
-import com.dobugs.yologaapi.service.dto.request.ParticipantsRequest;
+import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantResponse;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.dobugs.yologaapi.support.TokenGenerator;
@@ -74,7 +74,7 @@ class ParticipationServiceTest {
         @Test
         void success() {
             final long runningCrewId = 0L;
-            final ParticipantsRequest request = new ParticipantsRequest(0, 10);
+            final PagingRequest request = new PagingRequest(0, 10);
 
             final long memberId1 = 1L;
             final long memberId2 = 2L;

--- a/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
@@ -34,6 +34,7 @@ import com.dobugs.yologaapi.repository.RunningCrewRepository;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewFindNearbyRequest;
+import com.dobugs.yologaapi.service.dto.request.RunningCrewStatusRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
@@ -142,6 +143,75 @@ class RunningCrewServiceTest {
                 .toList();
 
             assertThat(memberIdsOfResponse).contains(MEMBER_ID);
+        }
+    }
+
+    @DisplayName("내가 주최한 러닝크루 목록 조회")
+    @Nested
+    public class findHosted {
+
+        @DisplayName("내가 주최한 러닝크루 목록을 조회한다")
+        @Test
+        void success() {
+            final String status = "CREATED";
+
+            final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final List<RunningCrew> runningCrews = List.of(createRunningCrew(MEMBER_ID));
+            final Page<RunningCrew> page = mock(Page.class);
+            given(page.getTotalElements()).willReturn(0L);
+            given(page.getNumber()).willReturn(10);
+            given(page.getSize()).willReturn(0);
+            given(page.getContent()).willReturn(runningCrews);
+            given(runningCrewRepository.findByMemberIdAndStatusAndArchivedIsTrue(eq(MEMBER_ID), eq(ProgressionType.CREATED), any()))
+                .willReturn(page);
+
+            final RunningCrewsResponse response = runningCrewService.findHosted(serviceToken, request);
+            final List<Long> memberIdsOfResponse = response.content().stream()
+                .map(RunningCrewResponse::host)
+                .toList();
+
+            assertThat(memberIdsOfResponse).contains(MEMBER_ID);
+        }
+
+        @DisplayName("러닝크루 상태값에 null 을 입력하면 모든 상태값의 러닝크루 목록을 조회한다")
+        @Test
+        void statusIsNull() {
+            final String status = null;
+
+            final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final List<RunningCrew> runningCrews = List.of(createRunningCrew(MEMBER_ID));
+            final Page<RunningCrew> page = mock(Page.class);
+            given(page.getTotalElements()).willReturn(0L);
+            given(page.getNumber()).willReturn(10);
+            given(page.getSize()).willReturn(0);
+            given(page.getContent()).willReturn(runningCrews);
+            given(runningCrewRepository.findByMemberIdAndArchivedIsTrue(eq(MEMBER_ID), any())).willReturn(page);
+
+            final RunningCrewsResponse response = runningCrewService.findHosted(serviceToken, request);
+            final List<Long> memberIdsOfResponse = response.content().stream()
+                .map(RunningCrewResponse::host)
+                .toList();
+
+            assertThat(memberIdsOfResponse).contains(MEMBER_ID);
+        }
+
+        @DisplayName("잘못된 상태값을 입력하면 예외가 발생한다")
+        @Test
+        void statusIsInvalid() {
+            final String invalidStatus = "invalidStatus";
+
+            final RunningCrewStatusRequest request = new RunningCrewStatusRequest(invalidStatus, 0, 10);
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            assertThatThrownBy(() -> runningCrewService.findHosted(serviceToken, request))
+                .isInstanceOf(IllegalArgumentException.class);
         }
     }
 


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-176
- https://dobugs.atlassian.net/browse/YOL-177
- https://dobugs.atlassian.net/browse/YOL-178

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 아래 기능들을 구현하였습니다.
  - 현재 진행중인 내 러닝크루 목록 조회
  - 내가 주최한 러닝크루 목록 조회
  - 내가 참여한 러닝크루 목록 조회
- 내가 주최한/참여한 러닝크루 목록 조회 요청 시 `status` 의 값을 입력하지 않으면(null 을 입력하면) 상태값 조건 없이 모든 러닝크루의 목록을 조회합니다.
- 내가 참여한 러닝크루 목록 조회 요청 시 사용자가 주최 + 참여한 모든 러닝크루 목록을 조회합니다.
- 내가 참여한 러닝크루 목록 조회 요청 시 러닝크루 참여 상태값은 '참여중' 인 러닝크루 목록만 조회합니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
