### PR TITLE
refactor: 인증 시 두벅스 서버에게 API 요청

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,8 +119,9 @@ jacocoTestCoverageVerification {
 
     def exceptions = [
             "*.exception.*",
-            "*.*Application",
             "*.dto.*",
+            "*.*Application",
+            "*.*Connector.*",
             "*.*Connector"
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,8 @@ jacocoTestCoverageVerification {
     def exceptions = [
             "*.exception.*",
             "*.*Application",
-            "*.dto.*"
+            "*.dto.*",
+            "*.*Connector"
     ]
 
     violationRules {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // rest template
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }
 
 /* RestDocs Start */

--- a/src/main/java/com/dobugs/yologaapi/auth/AuthInterceptor.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/AuthInterceptor.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -22,6 +23,9 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
         if (!hasMethodAnnotation((HandlerMethod) handler, Authorized.class)) {
             return true;
         }

--- a/src/main/java/com/dobugs/yologaapi/auth/AuthInterceptor.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/AuthInterceptor.java
@@ -1,0 +1,51 @@
+package com.dobugs.yologaapi.auth;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.dobugs.yologaapi.auth.dto.response.AuthorizationResponse;
+import com.dobugs.yologaapi.auth.exception.AuthorizationConnectorException;
+import com.dobugs.yologaapi.auth.support.Connector;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final Connector dobugsConnector;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        if (!hasMethodAnnotation((HandlerMethod) handler, Authorized.class)) {
+            return true;
+        }
+        final ResponseEntity<AuthorizationResponse> authorizationResponse = dobugsConnector.post(request, AuthorizationResponse.class);
+        validateConnectionResponseIsSuccess(authorizationResponse);
+        return true;
+    }
+
+    private <A extends Annotation> boolean hasMethodAnnotation(final HandlerMethod handler, final Class<A> annotationType) {
+        return handler.hasMethodAnnotation(annotationType);
+    }
+
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<AuthorizationResponse> response) {
+        final HttpStatusCode statusCode = response.getStatusCode();
+        if (!statusCode.is2xxSuccessful()) {
+            throw new AuthorizationConnectorException(getResponseMessage(response));
+        }
+    }
+
+    private String getResponseMessage(final ResponseEntity<AuthorizationResponse> response) {
+        final AuthorizationResponse body = response.getBody();
+        if (body == null) {
+            return "두벅스 서버와의 연결에 실패하였습니다.";
+        }
+        return body.message();
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/Authorized.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/Authorized.java
@@ -1,0 +1,11 @@
+package com.dobugs.yologaapi.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorized {
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/ExtractAuthorization.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/ExtractAuthorization.java
@@ -1,0 +1,11 @@
+package com.dobugs.yologaapi.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExtractAuthorization {
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/JWTPayload.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/JWTPayload.java
@@ -1,0 +1,19 @@
+package com.dobugs.yologaapi.auth;
+
+import lombok.Getter;
+
+@Getter
+public enum JWTPayload {
+
+    MEMBER_ID("memberId"),
+    PROVIDER("provider"),
+    TOKEN_TYPE("tokenType"),
+    TOKEN("token"),
+    ;
+
+    private final String name;
+
+    JWTPayload(final String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/TokenExtractor.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/TokenExtractor.java
@@ -1,0 +1,56 @@
+package com.dobugs.yologaapi.auth;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class TokenExtractor {
+
+    private static final String SERVICE_TOKEN_TYPE = "Bearer ";
+
+    private final SecretKey secretKey;
+
+    public TokenExtractor(
+        @Value("${jwt.token.secret-key}") final String secretKey
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));;
+    }
+
+    public ServiceToken extract(final String serviceToken) {
+        final String jwt = serviceToken.replace(SERVICE_TOKEN_TYPE, "");
+        final Claims claims = extractClaims(jwt);
+        return new ServiceToken(
+            extractMemberId(claims),
+            extract(claims, JWTPayload.PROVIDER),
+            extract(claims, JWTPayload.TOKEN_TYPE),
+            extract(claims, JWTPayload.TOKEN)
+        );
+    }
+
+    private Long extractMemberId(final Claims claims) {
+        final Integer memberId = (Integer) claims.get(JWTPayload.MEMBER_ID.getName());
+        return memberId.longValue();
+    }
+
+    private String extract(final Claims claims, final JWTPayload jwtPayload) {
+        return (String) claims.get(jwtPayload.getName());
+    }
+
+    private Claims extractClaims(final String serviceToken) {
+        return Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(serviceToken)
+            .getBody();
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/TokenResolver.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/TokenResolver.java
@@ -1,0 +1,46 @@
+package com.dobugs.yologaapi.auth;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.dobugs.yologaapi.auth.exception.AuthorizationException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TokenResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenExtractor tokenExtractor;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ExtractAuthorization.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+        final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+        return tokenExtractor.extract(extractAuthorizationHeader(request));
+    }
+
+    private String extractAuthorizationHeader(final HttpServletRequest request) {
+        final String authorization = request.getHeader("Authorization");
+        if (authorization ==  null) {
+            throw new AuthorizationException("토큰이 필요합니다.");
+        }
+        return decode(authorization);
+    }
+
+    private String decode(final String encoded) {
+        return URLDecoder.decode(encoded, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/dto/response/AuthorizationResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/dto/response/AuthorizationResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaapi.auth.dto.response;
+
+public record AuthorizationResponse(String message) {
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/dto/response/ServiceToken.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/dto/response/ServiceToken.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaapi.auth.dto.response;
+
+public record ServiceToken(Long memberId, String provider, String tokenType, String token) {
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/exception/AuthorizationConnectorException.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/exception/AuthorizationConnectorException.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaapi.auth.exception;
+
+public class AuthorizationConnectorException extends AuthorizationException {
+
+    public AuthorizationConnectorException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/exception/AuthorizationException.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/exception/AuthorizationException.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaapi.auth.exception;
+
+public class AuthorizationException extends RuntimeException {
+
+    public AuthorizationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/support/Connector.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/support/Connector.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaapi.auth.support;
+
+import org.springframework.http.ResponseEntity;
+
+public interface Connector {
+
+    <T> ResponseEntity<T> post(Object request, Class<T> responseType);
+}

--- a/src/main/java/com/dobugs/yologaapi/auth/support/Connector.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/support/Connector.java
@@ -2,7 +2,9 @@ package com.dobugs.yologaapi.auth.support;
 
 import org.springframework.http.ResponseEntity;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 public interface Connector {
 
-    <T> ResponseEntity<T> post(Object request, Class<T> responseType);
+    <T> ResponseEntity<T> post(HttpServletRequest request, Class<T> responseType);
 }

--- a/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
@@ -1,11 +1,14 @@
 package com.dobugs.yologaapi.auth.support;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
@@ -32,15 +35,16 @@ public class DobugsConnector implements Connector {
         final String authorization = request.getHeader("Authorization");
         return REST_TEMPLATE.postForEntity(
             authHost + authPath,
-            createAuthorizationHeaders(authorization),
+            createRequestEntity(authorization),
             responseType
         );
     }
 
-    private HttpHeaders createAuthorizationHeaders(final String token) {
+    private HttpEntity<MultiValueMap<String, String>> createRequestEntity(final String token) {
         final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", token);
-        return headers;
+        return new HttpEntity<>(headers);
     }
 
     private void config() {

--- a/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
@@ -1,14 +1,20 @@
 package com.dobugs.yologaapi.auth.support;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @Component
 public class DobugsConnector implements Connector {
 
-    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+    private final RestTemplate REST_TEMPLATE = new RestTemplate();
 
     private final String authHost;
     private final String authPath;
@@ -19,9 +25,30 @@ public class DobugsConnector implements Connector {
     ) {
         this.authHost = authHost;
         this.authPath = authPath;
+        config();
     }
 
-    public <T> ResponseEntity<T> post(final Object request, final Class<T> responseType) {
-        return REST_TEMPLATE.postForEntity(authHost + authPath, request, responseType);
+    public <T> ResponseEntity<T> post(final HttpServletRequest request, final Class<T> responseType) {
+        final String authorization = request.getHeader("Authorization");
+        return REST_TEMPLATE.postForEntity(
+            authHost + authPath,
+            createAuthorizationHeaders(authorization),
+            responseType
+        );
+    }
+
+    private HttpHeaders createAuthorizationHeaders(final String token) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", token);
+        return headers;
+    }
+
+    private void config() {
+        REST_TEMPLATE.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        REST_TEMPLATE.setErrorHandler(new DefaultResponseErrorHandler() {
+            public boolean hasError(final ClientHttpResponse response) {
+                return false;
+            }
+        });
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
+++ b/src/main/java/com/dobugs/yologaapi/auth/support/DobugsConnector.java
@@ -1,0 +1,27 @@
+package com.dobugs.yologaapi.auth.support;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class DobugsConnector implements Connector {
+
+    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+
+    private final String authHost;
+    private final String authPath;
+
+    public DobugsConnector(
+        @Value("${auth.host}") final String authHost,
+        @Value("${auth.path}") final String authPath
+    ) {
+        this.authHost = authHost;
+        this.authPath = authPath;
+    }
+
+    public <T> ResponseEntity<T> post(final Object request, final Class<T> responseType) {
+        return REST_TEMPLATE.postForEntity(authHost + authPath, request, responseType);
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/config/AuthConfiguration.java
+++ b/src/main/java/com/dobugs/yologaapi/config/AuthConfiguration.java
@@ -1,0 +1,23 @@
+package com.dobugs.yologaapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.dobugs.yologaapi.auth.AuthInterceptor;
+import com.dobugs.yologaapi.auth.support.Connector;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class AuthConfiguration implements WebMvcConfigurer {
+
+    private final Connector dobugsConnector;
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthInterceptor(dobugsConnector))
+            .addPathPatterns("/api/**");
+    }
+}

--- a/src/main/java/com/dobugs/yologaapi/config/AuthConfiguration.java
+++ b/src/main/java/com/dobugs/yologaapi/config/AuthConfiguration.java
@@ -1,10 +1,15 @@
 package com.dobugs.yologaapi.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.dobugs.yologaapi.auth.AuthInterceptor;
+import com.dobugs.yologaapi.auth.TokenExtractor;
+import com.dobugs.yologaapi.auth.TokenResolver;
 import com.dobugs.yologaapi.auth.support.Connector;
 
 import lombok.RequiredArgsConstructor;
@@ -14,10 +19,16 @@ import lombok.RequiredArgsConstructor;
 public class AuthConfiguration implements WebMvcConfigurer {
 
     private final Connector dobugsConnector;
+    private final TokenExtractor tokenExtractor;
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor(dobugsConnector))
             .addPathPatterns("/api/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new TokenResolver(tokenExtractor));
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -5,11 +5,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaapi.auth.Authorized;
+import com.dobugs.yologaapi.auth.ExtractAuthorization;
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaapi.service.ParticipationService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
@@ -35,52 +36,52 @@ public class ParticipationController {
     @Authorized
     @PostMapping("/participate")
     public ResponseEntity<Void> participate(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        participationService.participate(accessToken, runningCrewId);
+        participationService.participate(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/cancel")
     public ResponseEntity<Void> cancel(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        participationService.cancel(accessToken, runningCrewId);
+        participationService.cancel(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/withdraw")
     public ResponseEntity<Void> withdraw(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        participationService.withdraw(accessToken, runningCrewId);
+        participationService.withdraw(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/accept/{memberId}")
     public ResponseEntity<Void> accept(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId,
         @PathVariable final Long memberId
     ) {
-        participationService.accept(accessToken, runningCrewId, memberId);
+        participationService.accept(serviceToken, runningCrewId, memberId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/reject/{memberId}")
     public ResponseEntity<Void> reject(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId,
         @PathVariable final Long memberId
     ) {
-        participationService.reject(accessToken, runningCrewId, memberId);
+        participationService.reject(serviceToken, runningCrewId, memberId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/ParticipationController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dobugs.yologaapi.auth.Authorized;
 import com.dobugs.yologaapi.service.ParticipationService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
@@ -31,6 +32,7 @@ public class ParticipationController {
         return ResponseEntity.ok(response);
     }
 
+    @Authorized
     @PostMapping("/participate")
     public ResponseEntity<Void> participate(
         @RequestHeader("Authorization") final String accessToken,
@@ -40,6 +42,7 @@ public class ParticipationController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/cancel")
     public ResponseEntity<Void> cancel(
         @RequestHeader("Authorization") final String accessToken,
@@ -49,6 +52,7 @@ public class ParticipationController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/withdraw")
     public ResponseEntity<Void> withdraw(
         @RequestHeader("Authorization") final String accessToken,
@@ -58,6 +62,7 @@ public class ParticipationController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/accept/{memberId}")
     public ResponseEntity<Void> accept(
         @RequestHeader("Authorization") final String accessToken,
@@ -68,6 +73,7 @@ public class ParticipationController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/reject/{memberId}")
     public ResponseEntity<Void> reject(
         @RequestHeader("Authorization") final String accessToken,

--- a/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dobugs.yologaapi.auth.Authorized;
 import com.dobugs.yologaapi.service.RunningCrewService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
@@ -33,6 +34,7 @@ public class RunningCrewController {
 
     private final RunningCrewService runningCrewService;
 
+    @Authorized
     @PostMapping
     public ResponseEntity<Void> create(
         @RequestHeader("Authorization") final String accessToken,
@@ -48,6 +50,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Authorized
     @GetMapping("/in-progress")
     public ResponseEntity<RunningCrewsResponse> findInProgress(
         @RequestHeader("Authorization") final String accessToken,
@@ -57,6 +60,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Authorized
     @GetMapping("/hosted")
     public ResponseEntity<RunningCrewsResponse> findHosted(
         @RequestHeader("Authorization") final String accessToken,
@@ -66,6 +70,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Authorized
     @GetMapping("/participated")
     public ResponseEntity<RunningCrewsResponse> findParticipated(
         @RequestHeader("Authorization") final String accessToken,
@@ -81,6 +86,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Authorized
     @PutMapping("/{runningCrewId}")
     public ResponseEntity<Void> update(
         @RequestHeader("Authorization") final String accessToken,
@@ -91,6 +97,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @DeleteMapping("/{runningCrewId}")
     public ResponseEntity<Void> delete(
         @RequestHeader("Authorization") final String accessToken,
@@ -100,6 +107,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/{runningCrewId}/start")
     public ResponseEntity<Void> start(
         @RequestHeader("Authorization") final String accessToken,
@@ -109,6 +117,7 @@ public class RunningCrewController {
         return ResponseEntity.ok().build();
     }
 
+    @Authorized
     @PostMapping("/{runningCrewId}/end")
     public ResponseEntity<Void> end(
         @RequestHeader("Authorization") final String accessToken,

--- a/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
+++ b/src/main/java/com/dobugs/yologaapi/controller/RunningCrewController.java
@@ -10,11 +10,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaapi.auth.Authorized;
+import com.dobugs.yologaapi.auth.ExtractAuthorization;
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaapi.service.RunningCrewService;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.request.RunningCrewCreateRequest;
@@ -37,10 +38,10 @@ public class RunningCrewController {
     @Authorized
     @PostMapping
     public ResponseEntity<Void> create(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @RequestBody final RunningCrewCreateRequest request
     ) {
-        final long runningCrewId = runningCrewService.create(accessToken, request);
+        final long runningCrewId = runningCrewService.create(serviceToken, request);
         return ResponseEntity.created(URI.create("/api/v1/running-crews/" + runningCrewId)).build();
     }
 
@@ -53,30 +54,30 @@ public class RunningCrewController {
     @Authorized
     @GetMapping("/in-progress")
     public ResponseEntity<RunningCrewsResponse> findInProgress(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @ModelAttribute final PagingRequest request
     ) {
-        final RunningCrewsResponse response = runningCrewService.findInProgress(accessToken, request);
+        final RunningCrewsResponse response = runningCrewService.findInProgress(serviceToken, request);
         return ResponseEntity.ok().body(response);
     }
 
     @Authorized
     @GetMapping("/hosted")
     public ResponseEntity<RunningCrewsResponse> findHosted(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @ModelAttribute final RunningCrewStatusRequest request
     ) {
-        final RunningCrewsResponse response = runningCrewService.findHosted(accessToken, request);
+        final RunningCrewsResponse response = runningCrewService.findHosted(serviceToken, request);
         return ResponseEntity.ok().body(response);
     }
 
     @Authorized
     @GetMapping("/participated")
     public ResponseEntity<RunningCrewsResponse> findParticipated(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @ModelAttribute final RunningCrewStatusRequest request
     ) {
-        final RunningCrewsResponse response = runningCrewService.findParticipated(accessToken, request);
+        final RunningCrewsResponse response = runningCrewService.findParticipated(serviceToken, request);
         return ResponseEntity.ok().body(response);
     }
 
@@ -89,41 +90,41 @@ public class RunningCrewController {
     @Authorized
     @PutMapping("/{runningCrewId}")
     public ResponseEntity<Void> update(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId,
         @RequestBody final RunningCrewUpdateRequest request
     ) {
-        runningCrewService.update(accessToken, runningCrewId, request);
+        runningCrewService.update(serviceToken, runningCrewId, request);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @DeleteMapping("/{runningCrewId}")
     public ResponseEntity<Void> delete(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        runningCrewService.delete(accessToken, runningCrewId);
+        runningCrewService.delete(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/{runningCrewId}/start")
     public ResponseEntity<Void> start(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        runningCrewService.start(accessToken, runningCrewId);
+        runningCrewService.start(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 
     @Authorized
     @PostMapping("/{runningCrewId}/end")
     public ResponseEntity<Void> end(
-        @RequestHeader("Authorization") final String accessToken,
+        @ExtractAuthorization final ServiceToken serviceToken,
         @PathVariable final Long runningCrewId
     ) {
-        runningCrewService.end(accessToken, runningCrewId);
+        runningCrewService.end(serviceToken, runningCrewId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/exception/ControllerAdvice.java
+++ b/src/main/java/com/dobugs/yologaapi/exception/ControllerAdvice.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.dobugs.yologaapi.auth.exception.AuthorizationException;
 import com.dobugs.yologaapi.exception.dto.response.ExceptionResponse;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -51,6 +52,12 @@ public class ControllerAdvice {
     public ResponseEntity<ExceptionResponse> handleExpiredJwtException(ExpiredJwtException e) {
         final String message = "토큰의 만료 시간이 지났습니다.";
         final ExceptionResponse response = ExceptionResponse.from(message, e.getMessage());
+        return ResponseEntity.status(UNAUTHORIZED).body(response);
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthorizationException(AuthorizationException e) {
+        final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
         return ResponseEntity.status(UNAUTHORIZED).body(response);
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 import com.dobugs.yologaapi.repository.ParticipantRepository;
@@ -13,8 +14,6 @@ import com.dobugs.yologaapi.repository.dto.response.ParticipantDto;
 import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.dobugs.yologaapi.support.PagingGenerator;
-import com.dobugs.yologaapi.support.TokenGenerator;
-import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +24,6 @@ public class ParticipationService {
 
     private final RunningCrewRepository runningCrewRepository;
     private final ParticipantRepository participantRepository;
-    private final TokenGenerator tokenGenerator;
     private final PagingGenerator pagingGenerator;
 
     @Transactional(readOnly = true)
@@ -35,41 +33,30 @@ public class ParticipationService {
         return ParticipantsResponse.from(response);
     }
 
-    public void participate(final String serviceToken, final Long runningCrewId) {
-        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
-        final Long memberId = userTokenResponse.memberId();
-
+    public void participate(final ServiceToken serviceToken, final Long runningCrewId) {
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
-        savedRunningCrew.participate(memberId);
+        savedRunningCrew.participate(serviceToken.memberId());
     }
 
-    public void cancel(final String serviceToken, final Long runningCrewId) {
-        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
-        final Long memberId = userTokenResponse.memberId();
-
+    public void cancel(final ServiceToken serviceToken, final Long runningCrewId) {
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
-        savedRunningCrew.cancel(memberId);
+        savedRunningCrew.cancel(serviceToken.memberId());
     }
 
-    public void withdraw(final String serviceToken, final Long runningCrewId) {
-        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
-        final Long memberId = userTokenResponse.memberId();
-
+    public void withdraw(final ServiceToken serviceToken, final Long runningCrewId) {
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
-        savedRunningCrew.withdraw(memberId);
+        savedRunningCrew.withdraw(serviceToken.memberId());
     }
 
-    public void accept(final String serviceToken, final Long runningCrewId, final Long memberId) {
-        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
-        final Long hostId = userTokenResponse.memberId();
+    public void accept(final ServiceToken serviceToken, final Long runningCrewId, final Long memberId) {
+        final Long hostId = serviceToken.memberId();
 
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
         savedRunningCrew.accept(hostId, memberId);
     }
 
-    public void reject(final String serviceToken, final Long runningCrewId, final Long memberId) {
-        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
-        final Long hostId = userTokenResponse.memberId();
+    public void reject(final ServiceToken serviceToken, final Long runningCrewId, final Long memberId) {
+        final Long hostId = serviceToken.memberId();
 
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
         savedRunningCrew.reject(hostId, memberId);

--- a/src/main/resources/application-dobugs.yml
+++ b/src/main/resources/application-dobugs.yml
@@ -1,0 +1,3 @@
+auth:
+  host: https://api.dev.dobugs.co.kr
+  path: /api/v1/auth/login

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,5 @@ spring:
     active: dev
   config:
     import:
+      - application-dobugs.yml
       - yologa-security/application-jwt.yml

--- a/src/test/java/com/dobugs/yologaapi/auth/AuthInterceptorTest.java
+++ b/src/test/java/com/dobugs/yologaapi/auth/AuthInterceptorTest.java
@@ -1,0 +1,105 @@
+package com.dobugs.yologaapi.auth;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaapi.auth.dto.response.AuthorizationResponse;
+import com.dobugs.yologaapi.auth.support.DobugsConnector;
+
+@WebMvcTest(FakeController.class)
+@DisplayName("Auth 인터셉터 테스트")
+class AuthInterceptorTest {
+
+    private static final String BASIC_URL = "/api";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DobugsConnector dobugsConnector;
+
+    @MockBean
+    private TokenExtractor tokenExtractor;
+
+    @DisplayName("@Authorized 어노테이션이 없는 경우 테스트")
+    @Nested
+    public class hasNotAuthorizedAnnotation {
+
+        private static final String URL = BASIC_URL + "/hasNotAnnotation";
+
+        @DisplayName("@Authorized 어노테이션이 없을 경우 두벅스 서버에게 요청을 보내지 않는다")
+        @Test
+        void success() throws Exception {
+            mockMvc.perform(get(URL))
+                .andExpect(status().isOk())
+            ;
+        }
+    }
+
+    @DisplayName("@Authorized 어노테이션이 있는 경우 테스트")
+    @Nested
+    public class hasAuthorizedAnnotation {
+
+        private static final String URL = BASIC_URL + "/hasAuthorizedAnnotation";
+
+        @DisplayName("@Authorized 어노테이션이 있을 경우 두벅스 서버에게 요청을 보낸다")
+        @Test
+        void success() throws Exception {
+            final ResponseEntity response = mock(ResponseEntity.class);
+            given(response.getStatusCode()).willReturn(HttpStatus.OK);
+            given(dobugsConnector.post(any(), any())).willReturn(response);
+
+            mockMvc.perform(get(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isOk())
+            ;
+        }
+
+        @DisplayName("두벅스 서버의 응답이 2XX 이 아닐 경우 예외가 발생한다")
+        @Test
+        void statusIsNot2XX() throws Exception {
+            final String responseMessage = "message";
+
+            final ResponseEntity response = mock(ResponseEntity.class);
+            given(response.getStatusCode()).willReturn(HttpStatus.UNAUTHORIZED);
+            given(response.getBody()).willReturn(new AuthorizationResponse(responseMessage));
+            given(dobugsConnector.post(any(), any())).willReturn(response);
+
+            mockMvc.perform(get(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", containsString(responseMessage)))
+            ;
+        }
+
+        @DisplayName("두벅스 서버의 응답이 2XX 이 아니면서 Body 가 null 일 경우 욜로가 서버에서 지정한 메시지를 포함한 예외가 발생한다")
+        @Test
+        void statusIsNot2XXAndBodyIsNull() throws Exception {
+            final ResponseEntity response = mock(ResponseEntity.class);
+            given(response.getStatusCode()).willReturn(HttpStatus.UNAUTHORIZED);
+            given(response.getBody()).willReturn(null);
+            given(dobugsConnector.post(any(), any())).willReturn(response);
+
+            mockMvc.perform(get(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", containsString("두벅스 서버와의 연결에 실패하였습니다.")))
+            ;
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/auth/FakeController.java
+++ b/src/test/java/com/dobugs/yologaapi/auth/FakeController.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
+
 @RequestMapping("/api")
 @RestController
 public class FakeController {
@@ -17,6 +19,11 @@ public class FakeController {
     @Authorized
     @GetMapping("/hasAuthorizedAnnotation")
     public ResponseEntity<Void> hasAuthorizedAnnotation() {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/hasExtractAuthorizationAnnotation")
+    public ResponseEntity<Void> hasExtractAuthorizationAnnotation(@ExtractAuthorization final ServiceToken serviceToken) {
         return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/auth/FakeController.java
+++ b/src/test/java/com/dobugs/yologaapi/auth/FakeController.java
@@ -1,0 +1,22 @@
+package com.dobugs.yologaapi.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+public class FakeController {
+
+    @GetMapping("/hasNotAnnotation")
+    public ResponseEntity<Void> hasNotAnnotation() {
+        return ResponseEntity.ok().build();
+    }
+
+    @Authorized
+    @GetMapping("/hasAuthorizedAnnotation")
+    public ResponseEntity<Void> hasAuthorizedAnnotation() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/auth/TokenExtractorTest.java
+++ b/src/test/java/com/dobugs/yologaapi/auth/TokenExtractorTest.java
@@ -1,0 +1,132 @@
+package com.dobugs.yologaapi.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
+import com.dobugs.yologaapi.support.fixture.ServiceTokenFixture;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+
+@DisplayName("TokenExtractor 테스트")
+class TokenExtractorTest {
+
+    private static final String SECRET_KEY_VALUE = "secretKey".repeat(10);
+    private static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(SECRET_KEY_VALUE.getBytes(StandardCharsets.UTF_8));
+
+    private TokenExtractor tokenExtractor;
+
+    @BeforeEach
+    void setUp() {
+        tokenExtractor = new TokenExtractor(SECRET_KEY_VALUE);
+    }
+
+    @DisplayName("토큰 추출 테스트")
+    @Nested
+    public class extract {
+
+        private static final long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String TOKEN_TYPE = "Bearer";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Date EXPIRATION = new Date(new Date().getTime() + 10_000);
+
+        @DisplayName("token 을 추출한다")
+        @Test
+        void success() {
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .expiration(EXPIRATION)
+                .secretKey(SECRET_KEY)
+                .algorithm(SignatureAlgorithm.HS256)
+                .compact();
+
+            final ServiceToken userTokenResponse = tokenExtractor.extract(serviceToken);
+
+            assertAll(
+                () -> assertThat(userTokenResponse.memberId()).isEqualTo(MEMBER_ID),
+                () -> assertThat(userTokenResponse.token()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(userTokenResponse.provider()).isEqualTo(PROVIDER)
+            );
+        }
+
+        @DisplayName("잘못된 형식의 JWT 일 경우 예외가 발생한다")
+        @Test
+        void JWTIsMalformed() {
+            final String serviceToken = "malformedToken";
+
+            assertThatThrownBy(() -> tokenExtractor.extract(serviceToken))
+                .isInstanceOf(MalformedJwtException.class);
+        }
+
+        @DisplayName("지원하지 않는 JWT 일 경우 예외가 발생한다")
+        @Test
+        void JWTIsUnsupported() {
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .expiration(EXPIRATION)
+                .compact();
+
+            assertThatThrownBy(() -> tokenExtractor.extract(serviceToken))
+                .isInstanceOf(UnsupportedJwtException.class);
+        }
+
+        @DisplayName("서명이 다른 JWT 일 경우 예외가 발생한다")
+        @Test
+        void signatureIsDifferent() {
+            final SecretKey differentSecretKey = Keys.hmacShaKeyFor("differentKey".repeat(10).getBytes(StandardCharsets.UTF_8));
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .expiration(EXPIRATION)
+                .secretKey(differentSecretKey)
+                .algorithm(SignatureAlgorithm.HS256)
+                .compact();
+
+            assertThatThrownBy(() -> tokenExtractor.extract(serviceToken))
+                .isInstanceOf(SignatureException.class);
+        }
+
+        @DisplayName("만료 시간이 지난 JWT 일 경우 예외가 발생한다")
+        @Test
+        void JWTIsExpired() {
+            final Date expiration = new Date(new Date().getTime() - 1);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .expiration(expiration)
+                .secretKey(SECRET_KEY)
+                .algorithm(SignatureAlgorithm.HS256)
+                .compact();
+
+            assertThatThrownBy(() -> tokenExtractor.extract(serviceToken))
+                .isInstanceOf(ExpiredJwtException.class);
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/auth/TokenResolverTest.java
+++ b/src/test/java/com/dobugs/yologaapi/auth/TokenResolverTest.java
@@ -1,0 +1,79 @@
+package com.dobugs.yologaapi.auth;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
+import com.dobugs.yologaapi.auth.support.DobugsConnector;
+
+@AutoConfigureMockMvc
+@WebMvcTest(FakeController.class)
+@DisplayName("Token 리졸버 테스트")
+class TokenResolverTest {
+
+    private static final String BASIC_URL = "/api";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DobugsConnector dobugsConnector;
+
+    @MockBean
+    private TokenExtractor tokenExtractor;
+
+    @DisplayName("@ExtractAuthorization 어노테이션에 없는 경우 테스트")
+    @Nested
+    public class hasNotAnnotation {
+
+        private static final String URL = BASIC_URL + "/hasNotAnnotation";
+
+        @DisplayName("@ExtractAuthorization 어노테이션이 없을 경우 객체로 추출하지 않는다")
+        @Test
+        void success() throws Exception {
+            mockMvc.perform(get(URL))
+                .andExpect(status().isOk())
+            ;
+        }
+    }
+
+    @DisplayName("@ExtractAuthorization 어노테이션이 있는 경우 테스트")
+    @Nested
+    public class hasLoginUserAnnotation {
+
+        private static final String URL = BASIC_URL + "/hasExtractAuthorizationAnnotation";
+
+        @DisplayName("@ExtractAuthorization 어노테이션이 있을 경우 객체를 추출한다")
+        @Test
+        void success() throws Exception {
+            given(tokenExtractor.extract(any())).willReturn(new ServiceToken(0L, "google", "Bearer", "token"));
+
+            mockMvc.perform(get(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isOk())
+            ;
+        }
+
+        @DisplayName("Authorization 헤더에 JWT 가 없을 경우 예외가 발생한다")
+        @Test
+        void notExistAuthorizationHeader() throws Exception {
+            mockMvc.perform(get(URL))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", containsString("토큰이 필요합니다.")))
+            ;
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/controller/ControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ControllerTest.java
@@ -1,0 +1,46 @@
+package com.dobugs.yologaapi.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaapi.auth.TokenExtractor;
+import com.dobugs.yologaapi.auth.support.DobugsConnector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+public class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenExtractor tokenExtractor;
+
+    @MockBean
+    private DobugsConnector dobugsConnector;
+
+    @BeforeEach
+    void setUp() {
+        final ResponseEntity response = mock(ResponseEntity.class);
+        lenient().when(response.getStatusCode()).thenReturn(HttpStatus.OK);
+        lenient().when(dobugsConnector.post(any(), any())).thenReturn(response);
+    }
+}

--- a/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/ParticipationControllerTest.java
@@ -15,37 +15,20 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.dobugs.yologaapi.service.ParticipationService;
 import com.dobugs.yologaapi.service.dto.response.ParticipantResponse;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
 @WebMvcTest(ParticipationController.class)
-@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
 @DisplayName("Participation 컨트롤러 테스트")
-class ParticipationControllerTest {
+class ParticipationControllerTest extends ControllerTest {
 
     private static final String BASIC_URL = "/api/v1/running-crews";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private ParticipationService participationService;

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -8,6 +8,7 @@ import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewUpdateRequest;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -103,7 +104,6 @@ class RunningCrewControllerTest extends ControllerTest {
     @DisplayName("현재 진행중인 내 러닝크루 목록을 조회한다")
     @Test
     void findInProgress() throws Exception {
-        final String accessToken = "accessToken";
         final int page = 0;
         final int size = 10;
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -112,10 +112,10 @@ class RunningCrewControllerTest extends ControllerTest {
 
         final PagingRequest request = new PagingRequest(page, size);
         final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
-        given(runningCrewService.findInProgress(accessToken, request)).willReturn(response);
+        given(runningCrewService.findInProgress(any(), eq(request))).willReturn(response);
 
         mockMvc.perform(get(BASIC_URL + "/in-progress")
-                .header("Authorization", accessToken)
+                .header("Authorization", "accessToken")
                 .params(params))
             .andExpect(status().isOk())
             .andDo(document(
@@ -129,7 +129,6 @@ class RunningCrewControllerTest extends ControllerTest {
     @DisplayName("내가 주최한 러닝크루 목록을 조회한다")
     @Test
     void findHosted() throws Exception {
-        final String accessToken = "accessToken";
         final String status = ProgressionType.CREATED.getSavedName();
         final int page = 0;
         final int size = 10;
@@ -140,10 +139,10 @@ class RunningCrewControllerTest extends ControllerTest {
 
         final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, page, size);
         final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
-        given(runningCrewService.findHosted(accessToken, request)).willReturn(response);
+        given(runningCrewService.findHosted(any(), eq(request))).willReturn(response);
 
         mockMvc.perform(get(BASIC_URL + "/hosted")
-                .header("Authorization", accessToken)
+                .header("Authorization", "accessToken")
                 .params(params))
             .andExpect(status().isOk())
             .andDo(document(
@@ -157,7 +156,6 @@ class RunningCrewControllerTest extends ControllerTest {
     @DisplayName("내가 참여한 러닝크루 목록을 조회한다")
     @Test
     void findParticipated() throws Exception {
-        final String accessToken = "accessToken";
         final String status = ProgressionType.CREATED.getSavedName();
         final int page = 0;
         final int size = 10;
@@ -168,10 +166,10 @@ class RunningCrewControllerTest extends ControllerTest {
 
         final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, page, size);
         final RunningCrewsResponse response = new RunningCrewsResponse(1, page, size, List.of(createRunningCrewResponse(1L)));
-        given(runningCrewService.findParticipated(accessToken, request)).willReturn(response);
+        given(runningCrewService.findParticipated(any(), eq(request))).willReturn(response);
 
         mockMvc.perform(get(BASIC_URL + "/participated")
-                .header("Authorization", accessToken)
+                .header("Authorization", "accessToken")
                 .params(params))
             .andExpect(status().isOk())
             .andDo(document(

--- a/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
+++ b/src/test/java/com/dobugs/yologaapi/controller/RunningCrewControllerTest.java
@@ -3,10 +3,10 @@ package com.dobugs.yologaapi.controller;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.LATITUDE;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.LONGITUDE;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewCreateRequest;
-import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewSummaryResponse;
-import static org.hamcrest.Matchers.is;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewResponse;
+import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewSummaryResponse;
 import static com.dobugs.yologaapi.domain.runningcrew.fixture.RunningCrewFixture.createRunningCrewUpdateRequest;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -25,16 +25,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -47,22 +40,12 @@ import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewFindNearbyResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
 @WebMvcTest(RunningCrewController.class)
-@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
 @DisplayName("RunningCrew 컨트롤러 테스트")
-class RunningCrewControllerTest {
+class RunningCrewControllerTest extends ControllerTest {
 
     private static final String BASIC_URL = "/api/v1/running-crews";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @MockBean
     private RunningCrewService runningCrewService;

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -36,11 +36,6 @@ import com.dobugs.yologaapi.support.fixture.ServiceTokenFixture;
 @DisplayName("Participation 서비스 테스트")
 class ParticipationServiceTest {
 
-    private static final Long MEMBER_ID = 0L;
-    private static final String PROVIDER = "google";
-    private static final String ACCESS_TOKEN = "accessToken";
-    private static final Long HOST_ID = 1L;
-
     private ParticipationService participationService;
 
     @Mock
@@ -111,6 +106,11 @@ class ParticipationServiceTest {
     @Nested
     public class participate {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Long HOST_ID = 1L;
+
         @DisplayName("러닝크루에 참여 요청을 한다")
         @Test
         void success() {
@@ -139,6 +139,11 @@ class ParticipationServiceTest {
     @DisplayName("참여 요청 취소 테스트")
     @Nested
     public class cancel {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Long HOST_ID = 1L;
 
         @DisplayName("러닝크루에 참여 요청 취소를 한다")
         @Test
@@ -169,6 +174,11 @@ class ParticipationServiceTest {
     @DisplayName("탈퇴 테스트")
     @Nested
     public class withdraw {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Long HOST_ID = 1L;
 
         @DisplayName("러닝크루에 탈퇴한다")
         @Test
@@ -207,6 +217,11 @@ class ParticipationServiceTest {
     @Nested
     public class accept {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Long HOST_ID = 1L;
+
         @DisplayName("러닝크루 참여 요청을 승인한다")
         @Test
         void success() {
@@ -242,6 +257,11 @@ class ParticipationServiceTest {
     @DisplayName("참여 요청 거절 테스트")
     @Nested
     public class reject {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Long HOST_ID = 1L;
 
         @DisplayName("러닝크루 참여 요청을 거절한다")
         @Test

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaapi.domain.runningcrew.Participant;
 import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
@@ -29,10 +30,7 @@ import com.dobugs.yologaapi.service.dto.request.PagingRequest;
 import com.dobugs.yologaapi.service.dto.response.ParticipantResponse;
 import com.dobugs.yologaapi.service.dto.response.ParticipantsResponse;
 import com.dobugs.yologaapi.support.PagingGenerator;
-import com.dobugs.yologaapi.support.TokenGenerator;
-import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
-
-import io.jsonwebtoken.Jwts;
+import com.dobugs.yologaapi.support.fixture.ServiceTokenFixture;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Participation 서비스 테스트")
@@ -52,22 +50,11 @@ class ParticipationServiceTest {
     private ParticipantRepository participantRepository;
 
     @Mock
-    private TokenGenerator tokenGenerator;
-
-    @Mock
     private PagingGenerator pagingGenerator;
 
     @BeforeEach
     void setUp() {
-        participationService = new ParticipationService(runningCrewRepository, participantRepository, tokenGenerator, pagingGenerator);
-    }
-
-    private String createToken(final Long memberId, final String provider, final String token) {
-        return Jwts.builder()
-            .claim("memberId", memberId)
-            .claim("provider", provider)
-            .claim("token", token)
-            .compact();
+        participationService = new ParticipationService(runningCrewRepository, participantRepository, pagingGenerator);
     }
 
     @DisplayName("러닝크루 참여자 목록 조회 테스트")
@@ -128,9 +115,11 @@ class ParticipationServiceTest {
         @Test
         void success() {
             final long runningCrewId = 0L;
-
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
@@ -155,9 +144,11 @@ class ParticipationServiceTest {
         @Test
         void success() {
             final long runningCrewId = 0L;
-
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
@@ -184,10 +175,16 @@ class ParticipationServiceTest {
         void success() {
             final long runningCrewId = 0L;
 
-            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
-            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken memberServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
+            final ServiceToken hostServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(HOST_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
@@ -215,10 +212,16 @@ class ParticipationServiceTest {
         void success() {
             final long runningCrewId = 0L;
 
-            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
-            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken memberServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
+            final ServiceToken hostServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(HOST_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
@@ -245,10 +248,16 @@ class ParticipationServiceTest {
         void success() {
             final long runningCrewId = 0L;
 
-            final String memberServiceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            final String hostServiceToken = createToken(HOST_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(memberServiceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
-            given(tokenGenerator.extract(hostServiceToken)).willReturn(new UserTokenResponse(HOST_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken memberServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
+            final ServiceToken hostServiceToken = new ServiceTokenFixture.Builder()
+                .memberId(HOST_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));

--- a/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
@@ -46,10 +46,6 @@ import com.dobugs.yologaapi.support.fixture.ServiceTokenFixture;
 @DisplayName("RunningCrew 서비스 테스트")
 class RunningCrewServiceTest {
 
-    private static final Long MEMBER_ID = 0L;
-    private static final String PROVIDER = "google";
-    private static final String ACCESS_TOKEN = "accessToken";
-
     private RunningCrewService runningCrewService;
 
     @Mock
@@ -66,6 +62,10 @@ class RunningCrewServiceTest {
     @DisplayName("러닝크루 생성 테스트")
     @Nested
     public class create {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("러닝크루를 생성한다")
         @Test
@@ -114,6 +114,10 @@ class RunningCrewServiceTest {
     @Nested
     public class findInProgress {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+
         @DisplayName("현재 진행중인 내 러닝크루 목록을 조회한다")
         @Test
         void success() {
@@ -146,6 +150,10 @@ class RunningCrewServiceTest {
     @DisplayName("내가 주최한 러닝크루 목록 조회")
     @Nested
     public class findHosted {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("내가 주최한 러닝크루 목록을 조회한다")
         @Test
@@ -226,6 +234,9 @@ class RunningCrewServiceTest {
     public class findParticipated {
 
         private static final Long HOST_ID = -1L;
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("내가 참여한 러닝크루 목록을 조회한다")
         @Test
@@ -335,6 +346,10 @@ class RunningCrewServiceTest {
     @Nested
     public class update {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+
         @DisplayName("러닝크루를 수정한다")
         @Test
         void success() {
@@ -374,6 +389,10 @@ class RunningCrewServiceTest {
     @Nested
     public class delete {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+
         @DisplayName("러닝크루를 삭제한다")
         @Test
         void success() {
@@ -411,6 +430,10 @@ class RunningCrewServiceTest {
     @DisplayName("러닝크루 시작 테스트")
     @Nested
     public class start {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("러닝크루를 시작한다")
         @Test
@@ -452,6 +475,10 @@ class RunningCrewServiceTest {
     @DisplayName("러닝크루 종료 테스트")
     @Nested
     public class end {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("러닝크루를 종료한다")
         @Test

--- a/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/RunningCrewServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaapi.domain.runningcrew.ParticipantType;
 import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
@@ -39,10 +40,7 @@ import com.dobugs.yologaapi.service.dto.request.RunningCrewUpdateRequest;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewResponse;
 import com.dobugs.yologaapi.service.dto.response.RunningCrewsResponse;
 import com.dobugs.yologaapi.support.PagingGenerator;
-import com.dobugs.yologaapi.support.TokenGenerator;
-import com.dobugs.yologaapi.support.dto.response.UserTokenResponse;
-
-import io.jsonwebtoken.Jwts;
+import com.dobugs.yologaapi.support.fixture.ServiceTokenFixture;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RunningCrew 서비스 테스트")
@@ -58,22 +56,11 @@ class RunningCrewServiceTest {
     private RunningCrewRepository runningCrewRepository;
 
     @Mock
-    private TokenGenerator tokenGenerator;
-
-    @Mock
     private PagingGenerator pagingGenerator;
 
     @BeforeEach
     void setUp() {
-        runningCrewService = new RunningCrewService(runningCrewRepository, tokenGenerator, pagingGenerator);
-    }
-
-    private String createToken(final Long memberId, final String provider, final String token) {
-        return Jwts.builder()
-            .claim("memberId", memberId)
-            .claim("provider", provider)
-            .claim("token", token)
-            .compact();
+        runningCrewService = new RunningCrewService(runningCrewRepository, pagingGenerator);
     }
 
     @DisplayName("러닝크루 생성 테스트")
@@ -84,8 +71,11 @@ class RunningCrewServiceTest {
         @Test
         void success() {
             final RunningCrewCreateRequest request = createRunningCrewCreateRequest();
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew savedRunningCrew = mock(RunningCrew.class);
             given(savedRunningCrew.getId()).willReturn(MEMBER_ID);
@@ -128,8 +118,11 @@ class RunningCrewServiceTest {
         @Test
         void success() {
             final PagingRequest request = new PagingRequest(0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final List<RunningCrew> runningCrews = List.of(createRunningCrew(MEMBER_ID));
             final Page<RunningCrew> page = mock(Page.class);
@@ -160,8 +153,11 @@ class RunningCrewServiceTest {
             final String status = "CREATED";
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final List<RunningCrew> runningCrews = List.of(createRunningCrew(MEMBER_ID));
             final Page<RunningCrew> page = mock(Page.class);
@@ -186,8 +182,11 @@ class RunningCrewServiceTest {
             final String status = null;
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final List<RunningCrew> runningCrews = List.of(createRunningCrew(MEMBER_ID));
             final Page<RunningCrew> page = mock(Page.class);
@@ -211,8 +210,11 @@ class RunningCrewServiceTest {
             final String invalidStatus = "invalidStatus";
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(invalidStatus, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.findHosted(serviceToken, request))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -231,8 +233,11 @@ class RunningCrewServiceTest {
             final String status = "CREATED";
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final List<RunningCrew> runningCrews = List.of(createRunningCrew(HOST_ID));
             final Page<RunningCrew> page = mock(Page.class);
@@ -258,8 +263,11 @@ class RunningCrewServiceTest {
             final String status = null;
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(status, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final List<RunningCrew> runningCrews = List.of(createRunningCrew(HOST_ID));
             final Page<RunningCrew> page = mock(Page.class);
@@ -283,8 +291,11 @@ class RunningCrewServiceTest {
             final String invalidStatus = "invalidStatus";
 
             final RunningCrewStatusRequest request = new RunningCrewStatusRequest(invalidStatus, 0, 10);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.findParticipated(serviceToken, request))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -329,8 +340,11 @@ class RunningCrewServiceTest {
         void success() {
             final long runningCrewId = 0L;
             final RunningCrewUpdateRequest request = createRunningCrewUpdateRequest();
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew savedRunningCrew = mock(RunningCrew.class);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(savedRunningCrew));
@@ -344,8 +358,11 @@ class RunningCrewServiceTest {
         void isShouldExist() {
             final long notExistRunningCrewId = 0L;
             final RunningCrewUpdateRequest request = createRunningCrewUpdateRequest();
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.update(serviceToken, notExistRunningCrewId, request))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -361,8 +378,11 @@ class RunningCrewServiceTest {
         @Test
         void success() {
             final long runningCrewId = 1L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew savedRunningCrew = createRunningCrew(MEMBER_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(savedRunningCrew));
@@ -376,8 +396,11 @@ class RunningCrewServiceTest {
         @Test
         void isShouldExist() {
             final long notExistId = 0L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.delete(serviceToken, notExistId))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -393,8 +416,11 @@ class RunningCrewServiceTest {
         @Test
         void success() {
             final long runningCrewId = 1L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew savedRunningCrew = createRunningCrew(MEMBER_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(savedRunningCrew));
@@ -411,8 +437,11 @@ class RunningCrewServiceTest {
         @Test
         void isShouldExist() {
             final long notExistId = 0L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.start(serviceToken, notExistId))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -428,8 +457,11 @@ class RunningCrewServiceTest {
         @Test
         void success() {
             final long runningCrewId = 1L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             final RunningCrew savedRunningCrew = createRunningCrew(MEMBER_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(savedRunningCrew));
@@ -447,8 +479,11 @@ class RunningCrewServiceTest {
         @Test
         void isShouldExist() {
             final long notExistId = 0L;
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            final ServiceToken serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .token(ACCESS_TOKEN)
+                .build();
 
             assertThatThrownBy(() -> runningCrewService.end(serviceToken, notExistId))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaapi/support/fixture/ServiceTokenFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/support/fixture/ServiceTokenFixture.java
@@ -1,0 +1,90 @@
+package com.dobugs.yologaapi.support.fixture;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import com.dobugs.yologaapi.auth.dto.response.ServiceToken;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+public class ServiceTokenFixture {
+
+    public static class Builder {
+
+        private Long memberId;
+        private String provider;
+        private String tokenType;
+        private String token;
+        private Date expiration;
+        private SecretKey secretKey;
+        private SignatureAlgorithm algorithm;
+
+        public Builder() {
+        }
+
+        public String compact() {
+            final JwtBuilder jwtBuilder = Jwts.builder();
+            if (memberId != null) {
+                jwtBuilder.claim("memberId", memberId);
+            }
+            if (provider != null) {
+                jwtBuilder.claim("provider", provider);
+            }
+            if (tokenType != null) {
+                jwtBuilder.claim("tokenType", tokenType);
+            }
+            if (token != null) {
+                jwtBuilder.claim("token", token);
+            }
+            if (expiration != null) {
+                jwtBuilder.setExpiration(expiration);
+            }
+            if (secretKey != null && algorithm != null) {
+                jwtBuilder.signWith(secretKey, algorithm);
+            }
+            return jwtBuilder.compact();
+        }
+
+        public ServiceToken build() {
+            return new ServiceToken(memberId, provider, tokenType, token);
+        }
+
+        public Builder memberId(final Long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public Builder provider(final String provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        public Builder tokenType(final String tokenType) {
+            this.tokenType = tokenType;
+            return this;
+        }
+
+        public Builder token(final String token) {
+            this.token = token;
+            return this;
+        }
+
+        public Builder expiration(final Date expiration) {
+            this.expiration = expiration;
+            return this;
+        }
+
+        public Builder secretKey(final SecretKey secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Builder algorithm(final SignatureAlgorithm algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-186

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 사용자 및 인증 기능을 담당하는 두벅스 서버에게 로그인 인증 과정을 위임하였습니다.
  - 욜로가 서버에서 불필요한 코드 제거
  - 중복적인 코드 제거
  - 명확한 역할 분담

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
