### PR TITLE
refactor: 비관적 락 적용

### DIFF
--- a/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
+++ b/src/main/java/com/dobugs/yologaapi/repository/RunningCrewRepository.java
@@ -5,14 +5,21 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import com.dobugs.yologaapi.domain.runningcrew.ProgressionType;
 import com.dobugs.yologaapi.domain.runningcrew.RunningCrew;
 
+import jakarta.persistence.LockModeType;
+
 public interface RunningCrewRepository extends JpaRepository<RunningCrew, Long> {
 
     Optional<RunningCrew> findByIdAndArchivedIsTrue(final Long id);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM RunningCrew r WHERE r.id = :id AND r.archived = true")
+    Optional<RunningCrew> findByIdAndArchivedIsTrueForUpdate(final Long id);
 
     @Query(
         value = "SELECT *\n"

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -34,7 +34,7 @@ public class ParticipationService {
     }
 
     public void participate(final ServiceToken serviceToken, final Long runningCrewId) {
-        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        final RunningCrew savedRunningCrew = findRunningCrewForUpdate(runningCrewId);
         savedRunningCrew.participate(serviceToken.memberId());
     }
 
@@ -44,7 +44,7 @@ public class ParticipationService {
     }
 
     public void withdraw(final ServiceToken serviceToken, final Long runningCrewId) {
-        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        final RunningCrew savedRunningCrew = findRunningCrewForUpdate(runningCrewId);
         savedRunningCrew.withdraw(serviceToken.memberId());
     }
 
@@ -64,6 +64,11 @@ public class ParticipationService {
 
     private RunningCrew findRunningCrewBy(final Long runningCrewId) {
         return runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)
+            .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));
+    }
+
+    private RunningCrew findRunningCrewForUpdate(final Long runningCrewId) {
+        return runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("러닝크루가 존재하지 않습니다. [%d]", runningCrewId)));
     }
 }

--- a/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaapi/repository/RunningCrewRepositoryTest.java
@@ -71,6 +71,48 @@ class RunningCrewRepositoryTest {
         }
     }
 
+    @DisplayName("러닝크루 아이디를 이용하여 러닝크루 정보 조회 (비관적 락)")
+    @Nested
+    public class findByIdAndArchivedIsTrueForUpdate {
+
+        private static final Long HOST_ID = 0L;
+
+        @DisplayName("archived 가 true 일 경우 RunningCrew 를 조회한다")
+        @Test
+        void archivedIsTrue() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            final RunningCrew savedRunningCrew = runningCrewRepository.save(runningCrew);
+
+            final Optional<RunningCrew> actual = runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(savedRunningCrew.getId());
+
+            assertThat(actual).isPresent();
+        }
+
+        @DisplayName("archived 가 false 일 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void archivedIsFalse() {
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+            runningCrew.delete(HOST_ID);
+            final RunningCrew savedRunningCrew = runningCrewRepository.save(runningCrew);
+
+            assertAll(
+                () -> assertThat(runningCrewRepository.findById(savedRunningCrew.getId())).isPresent(),
+                () -> assertThat(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(savedRunningCrew.getId())).isEmpty()
+            );
+        }
+
+        @DisplayName("RunningCrew 가 존재하지 않을 경우 RunningCrew 를 조회하지 못한다")
+        @Test
+        void notExist() {
+            final long notExistRunningCrewId = 0L;
+
+            assertAll(
+                () -> assertThat(runningCrewRepository.findById(notExistRunningCrewId)).isEmpty(),
+                () -> assertThat(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(notExistRunningCrewId)).isEmpty()
+            );
+        }
+    }
+
     @DisplayName("내 주변 러닝크루 목록 조회")
     @Nested
     public class findNearby {

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -122,7 +122,7 @@ class ParticipationServiceTest {
                 .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
-            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+            given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(serviceToken, runningCrewId);
 
@@ -157,6 +157,7 @@ class ParticipationServiceTest {
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+            given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(serviceToken, runningCrewId);
             participationService.cancel(serviceToken, runningCrewId);
@@ -198,6 +199,7 @@ class ParticipationServiceTest {
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+            given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(memberServiceToken, runningCrewId);
             participationService.accept(hostServiceToken, runningCrewId, MEMBER_ID);
@@ -240,6 +242,7 @@ class ParticipationServiceTest {
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+            given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(memberServiceToken, runningCrewId);
             participationService.accept(hostServiceToken, runningCrewId, MEMBER_ID);
@@ -281,6 +284,7 @@ class ParticipationServiceTest {
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
             given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
+            given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(memberServiceToken, runningCrewId);
             participationService.reject(hostServiceToken, runningCrewId, MEMBER_ID);


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-190

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 러닝크루 참여하기, 탈퇴하기 기능에서 동시성 문제가 발생할 가능성이 있어 비관적 락을 적용하였습니다.
  - 참여하기 : 설정한 인원 수보다 많은 인원이 참여할 가능성
  - 탈퇴하기 : 모두 탈퇴하여 주최자만 남을 경우 상태값이 바뀌어야 하는데 바뀌지 않을 가능성
- 비관적 락은 실제로 DB 에 락을 걸기 때문에 성능이 나빠지는 것을 최소화하기 위해 쿼리문은 동일하나 용도가 다른 메서드를 하나 추가하였습니다. (findByIdAndArchivedIsTrueForUpdate)

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
