### PR TITLE
refactor: 러닝크루 상세정보 조회 API 에 참여자 수 추가

### DIFF
--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/Participants.java
@@ -64,7 +64,7 @@ public class Participants {
         }
     }
 
-    public int getNumberOrParticipants() {
+    public int getNumberOfParticipants() {
         final List<Participant> participants = value.stream()
             .filter(value -> value.getStatus().isParticipating())
             .toList();

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -48,6 +48,9 @@ public class RunningCrew extends BaseEntity {
     private Capacity capacity;
 
     @Column(nullable = false)
+    private int numberOfParticipants;
+
+    @Column(nullable = false)
     private LocalDateTime scheduledStartDate;
 
     @Column(nullable = false)
@@ -79,6 +82,7 @@ public class RunningCrew extends BaseEntity {
         this.status = ProgressionType.CREATED;
         this.participants = new Participants(this);
         this.capacity = capacity;
+        this.numberOfParticipants = participants.getNumberOfParticipants();
         this.scheduledStartDate = scheduledStartDate;
         this.scheduledEndDate = scheduledEndDate;
         this.deadline = deadline;
@@ -142,6 +146,7 @@ public class RunningCrew extends BaseEntity {
     public void withdraw(final Long memberId) {
         validateMemberIsNotHost(memberId);
         participants.withdraw(memberId);
+        numberOfParticipants = participants.getNumberOfParticipants();
         initializeProgress();
     }
 
@@ -151,6 +156,7 @@ public class RunningCrew extends BaseEntity {
         deadline.validateDeadlineIsNotOver();
         validateRunningCrewStatusIsCreatedOrReadyOrInProgress();
         participants.accept(memberId);
+        numberOfParticipants = participants.getNumberOfParticipants();
         ready();
     }
 

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -161,7 +161,7 @@ public class RunningCrew extends BaseEntity {
     }
 
     private void initializeProgress() {
-        final int number = participants.getNumberOrParticipants();
+        final int number = participants.getNumberOfParticipants();
         if (number == 1 && status.isCreatedOrReady()) {
             status = ProgressionType.CREATED;
         }
@@ -230,5 +230,9 @@ public class RunningCrew extends BaseEntity {
         } catch (ParseException e) {
             throw new IllegalArgumentException(e.getMessage());
         }
+    }
+
+    public int getNumberOfParticipants() {
+        return participants.getNumberOfParticipants();
     }
 }

--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -237,8 +237,4 @@ public class RunningCrew extends BaseEntity {
             throw new IllegalArgumentException(e.getMessage());
         }
     }
-
-    public int getNumberOfParticipants() {
-        return participants.getNumberOfParticipants();
-    }
 }

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -50,7 +50,7 @@ public class ParticipationService {
 
     public void accept(final ServiceToken serviceToken, final Long runningCrewId, final Long memberId) {
         final Long hostId = serviceToken.memberId();
-        final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
+        final RunningCrew savedRunningCrew = findRunningCrewForUpdate(runningCrewId);
         savedRunningCrew.accept(hostId, memberId);
     }
 

--- a/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
+++ b/src/main/java/com/dobugs/yologaapi/service/ParticipationService.java
@@ -50,14 +50,12 @@ public class ParticipationService {
 
     public void accept(final ServiceToken serviceToken, final Long runningCrewId, final Long memberId) {
         final Long hostId = serviceToken.memberId();
-
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
         savedRunningCrew.accept(hostId, memberId);
     }
 
     public void reject(final ServiceToken serviceToken, final Long runningCrewId, final Long memberId) {
         final Long hostId = serviceToken.memberId();
-
         final RunningCrew savedRunningCrew = findRunningCrewBy(runningCrewId);
         savedRunningCrew.reject(hostId, memberId);
     }

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
@@ -7,7 +7,8 @@ import com.dobugs.yologaapi.service.dto.common.DatesDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
 
 public record RunningCrewResponse(Long id, String title, Long host, LocationsDto location, String status,
-                                  int capacity, DatesDto date, LocalDateTime deadline, String description) {
+                                  int capacity, int numberOfParticipants, DatesDto date, LocalDateTime deadline,
+                                  String description) {
 
     public static RunningCrewResponse from(final RunningCrew runningCrew) {
         return new RunningCrewResponse(
@@ -17,6 +18,7 @@ public record RunningCrewResponse(Long id, String title, Long host, LocationsDto
             LocationsDto.from(runningCrew.getDeparture(), runningCrew.getArrival()),
             runningCrew.getStatus().name(),
             runningCrew.getCapacity().getValue(),
+            runningCrew.getNumberOfParticipants(),
             DatesDto.from(
                 runningCrew.getScheduledStartDate(), runningCrew.getScheduledEndDate(),
                 runningCrew.getImplementedStartDate(), runningCrew.getImplementedEndDate()

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/ParticipantsTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -223,7 +222,7 @@ class ParticipantsTest {
             participants.temporaryJoin(runningCrew, 2L);
             participants.temporaryJoin(runningCrew, 3L);
 
-            final int numberOrParticipants = participants.getNumberOrParticipants();
+            final int numberOrParticipants = participants.getNumberOfParticipants();
 
             assertThat(numberOrParticipants).isEqualTo(1);
         }

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -35,11 +35,16 @@ class RunningCrewTest {
         @DisplayName("러닝크루를 생성한다")
         @Test
         void success() {
-            assertThatCode(() -> new RunningCrew(
+            final RunningCrew runningCrew = new RunningCrew(
                 HOST_ID, COORDINATES, COORDINATES, new Capacity(RUNNING_CREW_CAPACITY),
                 NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
                 RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
-            )).doesNotThrowAnyException();
+            );
+            assertAll(
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.CREATED),
+                () -> assertThat(runningCrew.getParticipants().getValue()).hasSize(1),
+                () -> assertThat(runningCrew.getNumberOfParticipants()).isEqualTo(1)
+            );
         }
 
         @DisplayName("시작 시간은 종료 시간보다 앞서있어야 한다")
@@ -384,7 +389,8 @@ class RunningCrewTest {
             assertThat(participant).isPresent();
             assertAll(
                 () -> assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.WITHDRAWN),
-                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.CREATED)
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.CREATED),
+                () -> assertThat(runningCrew.getNumberOfParticipants()).isEqualTo(1)
             );
         }
 
@@ -422,7 +428,8 @@ class RunningCrewTest {
             assertThat(participant).isPresent();
             assertAll(
                 () -> assertThat(participant.get().getStatus()).isEqualTo(ParticipantType.PARTICIPATING),
-                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.READY)
+                () -> assertThat(runningCrew.getStatus()).isEqualTo(ProgressionType.READY),
+                () -> assertThat(runningCrew.getNumberOfParticipants()).isEqualTo(2)
             );
         }
 

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
@@ -34,6 +34,7 @@ public class RunningCrewFixture {
 
     public static final String RUNNING_CREW_TITLE = "열심히 달릴 사람~~";
     public static final int RUNNING_CREW_CAPACITY = 10;
+    public static final int NUMBER_OF_PARTICIPANTS = 1;
     public static final String RUNNING_CREW_DESCRIPTION = "정말 열심히 달릴 사람만 모집해요!!! XD";
 
     public static final LocalDateTime NOW = LocalDateTime.now();
@@ -117,7 +118,7 @@ public class RunningCrewFixture {
     public static RunningCrewResponse createRunningCrewResponse(final Long runningCrewId) {
         return new RunningCrewResponse(
             runningCrewId, RUNNING_CREW_TITLE, 1L, LOCATIONS_DTO, ProgressionType.CREATED.name(),
-            RUNNING_CREW_CAPACITY, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
+            RUNNING_CREW_CAPACITY, NUMBER_OF_PARTICIPANTS, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
         );
     }
 
@@ -131,6 +132,7 @@ public class RunningCrewFixture {
         given(runningCrew.getArrival()).willReturn(point);
         given(runningCrew.getStatus()).willReturn(ProgressionType.CREATED);
         given(runningCrew.getCapacity()).willReturn(new Capacity(RUNNING_CREW_CAPACITY));
+        given(runningCrew.getNumberOfParticipants()).willReturn(NUMBER_OF_PARTICIPANTS);
         given(runningCrew.getDeadline()).willReturn(new Deadline(AFTER_ONE_HOUR));
 
         return runningCrew;

--- a/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
+++ b/src/test/java/com/dobugs/yologaapi/service/ParticipationServiceTest.java
@@ -198,7 +198,6 @@ class ParticipationServiceTest {
                 .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
-            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
             given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(memberServiceToken, runningCrewId);
@@ -241,7 +240,6 @@ class ParticipationServiceTest {
                 .build();
 
             final RunningCrew runningCrew = createRunningCrew(HOST_ID);
-            given(runningCrewRepository.findByIdAndArchivedIsTrue(runningCrewId)).willReturn(Optional.of(runningCrew));
             given(runningCrewRepository.findByIdAndArchivedIsTrueForUpdate(runningCrewId)).willReturn(Optional.of(runningCrew));
 
             participationService.participate(memberServiceToken, runningCrewId);


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-204

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 러닝크루 상세정보 조회 기능에 참여자의 정보를 추가하니 실행되는 쿼리문이 1개에서 2개로 증가하였습니다.
- 쿼리문이 하나 늘어남에 따라 평균 응답 시간도 증가하여 이를 개선하기 위해 역정규화를 적용하였습니다.
  - 러닝크루 테이블에 참여자 수 컬럼 추가
- 가상 사용자 수 1000명이 계속해서 API 를 호출할 때의 상황에서, 약 2초의 성능 개선이 있었습니다. (3.5초 -> 1.4초)

## 관련 Docs

- [역정규화 이용하여 조회 성능 높이기](https://cactus-treatment-26e.notion.site/6b896f83fb7a48a48485cb9565a4cae6)

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
