### PR TITLE
refactor: 러닝크루 수정 시 역정규화 컬럼으로 조회

### DIFF
--- a/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
+++ b/src/main/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrew.java
@@ -98,7 +98,7 @@ public class RunningCrew extends BaseEntity {
     ) {
         validateMemberIsHost(memberId);
         validateStartIsBeforeThanEnd(scheduledStartDate, scheduledEndDate);
-        this.participants.validateCapacityIsOver(capacity);
+        validateCapacityIsOverThanNumberOfParticipants(capacity);
 
         this.departure = wktToPoint(departure);
         this.arrival = wktToPoint(arrival);
@@ -196,6 +196,12 @@ public class RunningCrew extends BaseEntity {
             throw new IllegalArgumentException(
                 String.format("시작 시간은 종료 시간보다 앞서있어야 합니다. [start : %s / end : %s]", start, end)
             );
+        }
+    }
+
+    private void validateCapacityIsOverThanNumberOfParticipants(final Capacity capacity) {
+        if (!capacity.isLeft(numberOfParticipants)) {
+            throw new IllegalArgumentException("참여자 수용인원이 다 찼습니다.");
         }
     }
 

--- a/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
+++ b/src/main/java/com/dobugs/yologaapi/service/dto/response/RunningCrewResponse.java
@@ -7,7 +7,7 @@ import com.dobugs.yologaapi.service.dto.common.DatesDto;
 import com.dobugs.yologaapi.service.dto.common.LocationsDto;
 
 public record RunningCrewResponse(Long id, String title, Long host, LocationsDto location, String status,
-                                  int capacity, int numberOfParticipants, DatesDto date, LocalDateTime deadline,
+                                  int capacity, DatesDto date, LocalDateTime deadline,
                                   String description) {
 
     public static RunningCrewResponse from(final RunningCrew runningCrew) {
@@ -18,7 +18,6 @@ public record RunningCrewResponse(Long id, String title, Long host, LocationsDto
             LocationsDto.from(runningCrew.getDeparture(), runningCrew.getArrival()),
             runningCrew.getStatus().name(),
             runningCrew.getCapacity().getValue(),
-            runningCrew.getNumberOfParticipants(),
             DatesDto.from(
                 runningCrew.getScheduledStartDate(), runningCrew.getScheduledEndDate(),
                 runningCrew.getImplementedStartDate(), runningCrew.getImplementedEndDate()

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/RunningCrewTest.java
@@ -110,6 +110,26 @@ class RunningCrewTest {
             )).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("시작 시간은 종료 시간보다 앞서있어야 합니다.");
         }
+
+        @DisplayName("수용 인원은 현재 참여중인 인원보다 커야 한다")
+        @Test
+        void capacityIsLowerThanNumberOfParticipants() {
+            final Capacity capacity = new Capacity(2);
+            final RunningCrew runningCrew = createRunningCrew(HOST_ID);
+
+            runningCrew.participate(1L);
+            runningCrew.accept(HOST_ID, 1L);
+            runningCrew.participate(2L);
+            runningCrew.accept(HOST_ID, 2L);
+
+            assertThatThrownBy(() -> runningCrew.update(
+                HOST_ID,
+                COORDINATES, COORDINATES, capacity,
+                NOW, AFTER_ONE_HOUR, new Deadline(AFTER_ONE_HOUR),
+                RUNNING_CREW_TITLE, RUNNING_CREW_DESCRIPTION
+            )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("참여자 수용인원이 다 찼습니다.");
+        }
     }
 
     @DisplayName("러닝크루 삭제 테스트")

--- a/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
+++ b/src/test/java/com/dobugs/yologaapi/domain/runningcrew/fixture/RunningCrewFixture.java
@@ -34,7 +34,6 @@ public class RunningCrewFixture {
 
     public static final String RUNNING_CREW_TITLE = "열심히 달릴 사람~~";
     public static final int RUNNING_CREW_CAPACITY = 10;
-    public static final int NUMBER_OF_PARTICIPANTS = 1;
     public static final String RUNNING_CREW_DESCRIPTION = "정말 열심히 달릴 사람만 모집해요!!! XD";
 
     public static final LocalDateTime NOW = LocalDateTime.now();
@@ -118,7 +117,7 @@ public class RunningCrewFixture {
     public static RunningCrewResponse createRunningCrewResponse(final Long runningCrewId) {
         return new RunningCrewResponse(
             runningCrewId, RUNNING_CREW_TITLE, 1L, LOCATIONS_DTO, ProgressionType.CREATED.name(),
-            RUNNING_CREW_CAPACITY, NUMBER_OF_PARTICIPANTS, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
+            RUNNING_CREW_CAPACITY, DATES_DTO, AFTER_ONE_HOUR, RUNNING_CREW_DESCRIPTION
         );
     }
 
@@ -132,7 +131,6 @@ public class RunningCrewFixture {
         given(runningCrew.getArrival()).willReturn(point);
         given(runningCrew.getStatus()).willReturn(ProgressionType.CREATED);
         given(runningCrew.getCapacity()).willReturn(new Capacity(RUNNING_CREW_CAPACITY));
-        given(runningCrew.getNumberOfParticipants()).willReturn(NUMBER_OF_PARTICIPANTS);
         given(runningCrew.getDeadline()).willReturn(new Deadline(AFTER_ONE_HOUR));
 
         return runningCrew;


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-208

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 러닝크루 수정 시 러닝크루 테이블 뿐만 아니라 참여자 테이블도 조회하여 러닝크루 테이블에 추가한 참여자 수 컬럼을 이용하도록 수정하였습니다.

## 관련 Docs

- [역정규화 이용하여 불필요한 쿼리문 실행 개선하기](https://kyukong.notion.site/6b896f83fb7a48a48485cb9565a4cae6)

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
